### PR TITLE
Add support for custom HTML template wrapping markdown-to-html output

### DIFF
--- a/template.html
+++ b/template.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Good First Issues</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="content">
+    {{content}}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds support for wrapping the generated HTML (from README.md) inside a custom template.html file. This improves the structure and styling of the final index.html page.

**Changes Made**
Created template.html with a placeholder ({{content}}).

Modified index.js to inject converted markdown into the template.

Final HTML is now styled and better formatted.

**Related Issue**
Closes #2