### PR TITLE
feat: add sort and stale issue filter toggles to index.html (closes #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,103 @@ This is a list of JavaScript repositories with good first issues for newcomers t
 
 This list gets updated every day at midnight.
 
+## [naimkatiman/continuous-improvement](https://github.com/naimkatiman/continuous-improvement)
+
+- [Create 'Law of the Week' content series for X/Twitter](https://github.com/naimkatiman/continuous-improvement/issues/21)
+- [Write blog post: 'Why your AI agent keeps lying about being done'](https://github.com/naimkatiman/continuous-improvement/issues/11)
+- [Record a 2-min before/after demo video](https://github.com/naimkatiman/continuous-improvement/issues/10)
+- [Add full Gemini CLI integration (hooks + installer)](https://github.com/naimkatiman/continuous-improvement/issues/9)
+- [Submit to awesome-agent-skills listing](https://github.com/naimkatiman/continuous-improvement/issues/8)
+- [Fix version badge mismatch in README](https://github.com/naimkatiman/continuous-improvement/issues/7)
+- [Improve observe.sh hook with configurable triggers](https://github.com/naimkatiman/continuous-improvement/issues/5)
+- [Create CONTRIBUTING.md guide](https://github.com/naimkatiman/continuous-improvement/issues/3)
+- [Add unit tests for install.mjs](https://github.com/naimkatiman/continuous-improvement/issues/2)
+
+## [cdxgen/cdxgen](https://github.com/cdxgen/cdxgen)
+
+- [Update readme and docs regarding optional plugins](https://github.com/cdxgen/cdxgen/issues/599)
+
+## [WordPress/gutenberg](https://github.com/WordPress/gutenberg)
+
+- [Patterns from the pattern directory do not show if placed in a template](https://github.com/WordPress/gutenberg/issues/64104)
+- [Original PRs may not be tagged properly when a manual cherry-pick is performed.](https://github.com/WordPress/gutenberg/issues/76579)
+- [Page jumps away when trying to edit an anchor link](https://github.com/WordPress/gutenberg/issues/72505)
+- [Custom font upload not working](https://github.com/WordPress/gutenberg/issues/72265)
+- [Since 6.3, the display ratio of images is broken when the size of the Image Block is specified.](https://github.com/WordPress/gutenberg/issues/53555)
+- [Meta boxes: update core styles to match Gutenberg's](https://github.com/WordPress/gutenberg/issues/12101)
+- [Code Quality: Refactor all React class components to functional components using hooks](https://github.com/WordPress/gutenberg/issues/22890)
+- [Pasting direct image URL inserts Embed block instead of Image block](https://github.com/WordPress/gutenberg/issues/74734)
+
+## [vercel/next.js](https://github.com/vercel/next.js)
+
+- [Misleading "next-head-count is missing" error for invalid head tags](https://github.com/vercel/next.js/issues/20924)
+- [POST request succeeds for pages with next dev](https://github.com/vercel/next.js/issues/38863)
+- [Inconsistent Error Messaging / Handling in getStaticPaths](https://github.com/vercel/next.js/issues/41281)
+- [Parameter on `AppType` is used incorrectly](https://github.com/vercel/next.js/issues/42846)
+- [`@next/next/no-html-link-for-pages` rule does not work with `pageExtensions`](https://github.com/vercel/next.js/issues/53473)
+
+## [nodejs/node](https://github.com/nodejs/node)
+
+- [Runtime-deprecate calling digest() on HMAC more than once](https://github.com/nodejs/node/issues/62838)
+- [test_runner: node:coverage ignore comments exclude DA but leave BRDA in lcov output](https://github.com/nodejs/node/issues/61586)
+- [webstreams: narrow `ReadableStreamBYOBRequest.view` to `Uint8Array`](https://github.com/nodejs/node/issues/62952)
+- [crypto,quic: missing NULL checks for OpenSSL allocation functions](https://github.com/nodejs/node/issues/62774)
+- [Cpplint produces false positives for FastApiOptions](https://github.com/nodejs/node/issues/45761)
+- [Transpile TypeScript code inside `node_modules`.](https://github.com/nodejs/node/issues/58429)
+- [Recommend `node`/`default` conditions instead of `require`/`import` as a solution to the dual package hazard](https://github.com/nodejs/node/issues/52174)
+
+## [HarperFast/harper](https://github.com/HarperFast/harper)
+
+- [Incorrect logic for matching index.html](https://github.com/HarperFast/harper/issues/297)
+- [Update TLS privateKey to use relative path and update tests](https://github.com/HarperFast/harper/issues/307)
+- [Convert harper logger module to TypeScript](https://github.com/HarperFast/harper/issues/145)
+
+## [nextcloud/tables](https://github.com/nextcloud/tables)
+
+- [descriptions of the views missing upon import](https://github.com/nextcloud/tables/issues/2478)
+
+## [medic/cht-core](https://github.com/medic/cht-core)
+
+- [Replace `any` types with proper interfaces in small service files](https://github.com/medic/cht-core/issues/10883)
+- [Migrate small Angular templates from structural directives to built-in control flow](https://github.com/medic/cht-core/issues/10882)
+- [Add constants for 'task', 'target', and 'user-settings' document types](https://github.com/medic/cht-core/issues/10548)
+- [Add constant for 'contact' document type](https://github.com/medic/cht-core/issues/10545)
+- [Add constant for 'person' document type](https://github.com/medic/cht-core/issues/10543)
+- [Investigate loading externally hosted media into forms](https://github.com/medic/cht-core/issues/10323)
+
+## [meshery/meshery.io](https://github.com/meshery/meshery.io)
+
+- [GSoC Program 2026: Add hyperlink to Meshery org](https://github.com/meshery/meshery.io/issues/2661)
+
+## [LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN](https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN)
+
+- [Revisión de la documentación](https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/3)
+- [Sprints por hacer.](https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/2)
+
+## [HeyPuter/puter](https://github.com/HeyPuter/puter)
+
+- [Add support for `defaultValue` option for `puter.ui.setColorPicker` in puter app environment](https://github.com/HeyPuter/puter/issues/2895)
+- [Add support for `defaultValue` option for `puter.ui.prompt` in puter app environment](https://github.com/HeyPuter/puter/issues/2894)
+
+## [layer5io/layer5](https://github.com/layer5io/layer5)
+
+- [[Community] Member Profile: Lenox Wiltshire](https://github.com/layer5io/layer5/issues/7700)
+- [[Animation] Animate Meshery Architecture](https://github.com/layer5io/layer5/issues/7661)
+- [Add Meshery Relationships Tutorial to Newcomers page](https://github.com/layer5io/layer5/issues/7696)
+- [Update the structure of pages based on the latest sitemap revision available in Figma](https://github.com/layer5io/layer5/issues/5359)
+- [[Sistent] Add Table component to the Sistent components page](https://github.com/layer5io/layer5/issues/7607)
+- [[Sistent] Add Data Table component to the Sistent components page](https://github.com/layer5io/layer5/issues/7681)
+- [[SEO] First Contentful Paint (FCP): gatsby-plugin-webpack-bundle-analyser-v2](https://github.com/layer5io/layer5/issues/6449)
+- [[Screenshots] Old Screenshots of Meshery Playground needs to be updated](https://github.com/layer5io/layer5/issues/5342)
+- [[Performance] Improve Home Page Performance (layer5.io)](https://github.com/layer5io/layer5/issues/6924)
+- [Update resources and hands-on labs with latest content](https://github.com/layer5io/layer5/issues/6387)
+- [[CI] Create or add to existing workflow: a broken link checker](https://github.com/layer5io/layer5/issues/6407)
+- [[Sistent] Add ClickAwayListener component to the sistent components page](https://github.com/layer5io/layer5/issues/7668)
+- [add animated card](https://github.com/layer5io/layer5/issues/6521)
+- [[Sistent] Add Menu component to the sistent components page](https://github.com/layer5io/layer5/issues/7662)
+- [[Visual Design] New Recognition Badge: Event Evangelist Badge](https://github.com/layer5io/layer5/issues/4809)
+- [Improve styling of categories of models](https://github.com/layer5io/layer5/issues/7593)
+
 ## [nextcloud/spreed](https://github.com/nextcloud/spreed)
 
 - [Go back to autopilot mode if re-clicking selected participant](https://github.com/nextcloud/spreed/issues/3518)
@@ -18,16 +115,6 @@ This list gets updated every day at midnight.
 - [Temporary message added before date separator](https://github.com/nextcloud/spreed/issues/13777)
 - [Instant meeting outside of dashboard?](https://github.com/nextcloud/spreed/issues/15276)
 
-## [LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN](https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN)
-
-- [Revisión de la documentación](https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/3)
-- [Sprints por hacer.](https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/2)
-
-## [HeyPuter/puter](https://github.com/HeyPuter/puter)
-
-- [Add support for `defaultValue` option for `puter.ui.setColorPicker` in puter app environment](https://github.com/HeyPuter/puter/issues/2895)
-- [Add support for `defaultValue` option for `puter.ui.prompt` in puter app environment](https://github.com/HeyPuter/puter/issues/2894)
-
 ## [louislam/uptime-kuma](https://github.com/louislam/uptime-kuma)
 
 - [Navbar in mobile view has broken navbar position when on the list tab](https://github.com/louislam/uptime-kuma/issues/5977)
@@ -36,81 +123,9 @@ This list gets updated every day at midnight.
 - [Pausing a group does not pause the individual monitors of that group](https://github.com/louislam/uptime-kuma/issues/7242)
 - [Password Reset via CLI does not work on Embedded MariaDB](https://github.com/louislam/uptime-kuma/issues/5670)
 
-## [meshery/meshery.io](https://github.com/meshery/meshery.io)
+## [nodejs/undici](https://github.com/nodejs/undici)
 
-- [GSoC Program 2026: Add hyperlink to Meshery org](https://github.com/meshery/meshery.io/issues/2661)
-
-## [vercel/next.js](https://github.com/vercel/next.js)
-
-- [Misleading "next-head-count is missing" error for invalid head tags](https://github.com/vercel/next.js/issues/20924)
-- [POST request succeeds for pages with next dev](https://github.com/vercel/next.js/issues/38863)
-- [Inconsistent Error Messaging / Handling in getStaticPaths](https://github.com/vercel/next.js/issues/41281)
-- [Parameter on `AppType` is used incorrectly](https://github.com/vercel/next.js/issues/42846)
-- [`@next/next/no-html-link-for-pages` rule does not work with `pageExtensions`](https://github.com/vercel/next.js/issues/53473)
-
-## [HarperFast/harper](https://github.com/HarperFast/harper)
-
-- [Update TLS privateKey to use relative path and update tests](https://github.com/HarperFast/harper/issues/307)
-- [Convert harper logger module to TypeScript](https://github.com/HarperFast/harper/issues/145)
-
-## [cdxgen/cdxgen](https://github.com/cdxgen/cdxgen)
-
-- [Update readme and docs regarding optional plugins](https://github.com/cdxgen/cdxgen/issues/599)
-
-## [XRPLF/xrpl-dev-portal](https://github.com/XRPLF/xrpl-dev-portal)
-
-- [Update channel_authorize to reflect that it's restricted like other signing methods](https://github.com/XRPLF/xrpl-dev-portal/issues/3197)
-
-## [stdlib-js/stdlib](https://github.com/stdlib-js/stdlib)
-
-- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11936)
-- [Fix TypeScript declarations lint errors](https://github.com/stdlib-js/stdlib/issues/11896)
-- [Fix broken Markdown link: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about](https://github.com/stdlib-js/stdlib/issues/11868)
-- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11867)
-- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11784)
-- [[RFC]: Migrate `math/base/special` packages from relative tolerance testing to ULP difference testing (tracking issue)](https://github.com/stdlib-js/stdlib/issues/11352)
-
-## [hackforla/tdm-calculator](https://github.com/hackforla/tdm-calculator)
-
-- [FAQ database: Add content: I have an approved TDM Plan and my building has a Certificate of Occupancy. How do I modify my TDM Plan?](https://github.com/hackforla/tdm-calculator/issues/3022)
-- [FAQ database: Add content: What happens to my submitted, but not-yet-approved, TDM Plan if the TDM Program Guidelines change?](https://github.com/hackforla/tdm-calculator/issues/3018)
-- [Dev: Update the spelling linter exclusion list with new terms](https://github.com/hackforla/tdm-calculator/issues/3167)
-- [DEV: External links should open consistently across all pages.](https://github.com/hackforla/tdm-calculator/issues/3029)
-- [Bug: field focus on Page 1 is incorrect](https://github.com/hackforla/tdm-calculator/issues/3109)
-- [FAQ database: How to Submit a Snapshot](https://github.com/hackforla/tdm-calculator/issues/2754)
-- [FAQ database: Add content: How do I revise my proposed TDM Plan while keeping the same version of the Program Guidelines as my original submission?](https://github.com/hackforla/tdm-calculator/issues/3024)
-- [FAQ database: Add content: How do I make revisions to my submitted TDM Plan that were requested by LADOT?](https://github.com/hackforla/tdm-calculator/issues/3023)
-- [Dev: Update text when there are no results on Submissions page](https://github.com/hackforla/tdm-calculator/issues/3078)
-- [FAQ database: Add content: How can I search and filter my projects](https://github.com/hackforla/tdm-calculator/issues/2744)
-- [Dev: Fix column heading alignment and Date format on Security page](https://github.com/hackforla/tdm-calculator/issues/2580)
-
-## [UltiMafia/Ultimafia](https://github.com/UltiMafia/Ultimafia)
-
-- [feat(game): role marker should allow exact-searches](https://github.com/UltiMafia/Ultimafia/issues/2774)
-
-## [younisdev/dyvix-ui](https://github.com/younisdev/dyvix-ui)
-
-- [[Feature] Add `Warning` and `info` toast types.](https://github.com/younisdev/dyvix-ui/issues/100)
-- [[Chore] Move toast position styles into there own positions.css](https://github.com/younisdev/dyvix-ui/issues/96)
-
-## [q5js/q5.js](https://github.com/q5js/q5.js)
-
-- [Create more MSDF fonts to put in q5's fonts folder](https://github.com/q5js/q5.js/issues/123)
-
-## [carnworkstudios/TAFNE](https://github.com/carnworkstudios/TAFNE)
-
-- [Table style presets (theme picker)](https://github.com/carnworkstudios/TAFNE/issues/7)
-- [Handle Global Undo/Redo across Mode Switches](https://github.com/carnworkstudios/TAFNE/issues/4)
-- [Export Node Graph as SVG/PNG](https://github.com/carnworkstudios/TAFNE/issues/3)
-
-## [OREL-group/Project-Management](https://github.com/OREL-group/Project-Management)
-
-- [Add onboarding welcome screen for new users](https://github.com/OREL-group/Project-Management/issues/216)
-- [make a Start Here guide for plugin setup](https://github.com/OREL-group/Project-Management/issues/123)
-- [reaching out to investors](https://github.com/OREL-group/Project-Management/issues/95)
-- [create a organized database for the prototype](https://github.com/OREL-group/Project-Management/issues/90)
-- [Finalize Design Sprint Objectives](https://github.com/OREL-group/Project-Management/issues/50)
-- [Discover who we need to hire for the project](https://github.com/OREL-group/Project-Management/issues/39)
+- [interceptors: move signal handling to interceptor](https://github.com/nodejs/undici/issues/3276)
 
 ## [PipedreamHQ/pipedream](https://github.com/PipedreamHQ/pipedream)
 
@@ -148,39 +163,66 @@ This list gets updated every day at midnight.
 - [[ACTION] Add CoinAPI MCP Server integration](https://github.com/PipedreamHQ/pipedream/issues/18821)
 - [[ACTION] Get DPD parcel status](https://github.com/PipedreamHQ/pipedream/issues/20027)
 
-## [WordPress/gutenberg](https://github.com/WordPress/gutenberg)
+## [XRPLF/xrpl-dev-portal](https://github.com/XRPLF/xrpl-dev-portal)
 
-- [Patterns from the pattern directory do not show if placed in a template](https://github.com/WordPress/gutenberg/issues/64104)
-- [Original PRs may not be tagged properly when a manual cherry-pick is performed.](https://github.com/WordPress/gutenberg/issues/76579)
-- [Page jumps away when trying to edit an anchor link](https://github.com/WordPress/gutenberg/issues/72505)
-- [Custom font upload not working](https://github.com/WordPress/gutenberg/issues/72265)
-- [Since 6.3, the display ratio of images is broken when the size of the Image Block is specified.](https://github.com/WordPress/gutenberg/issues/53555)
-- [Meta boxes: update core styles to match Gutenberg's](https://github.com/WordPress/gutenberg/issues/12101)
-- [Code Quality: Refactor all React class components to functional components using hooks](https://github.com/WordPress/gutenberg/issues/22890)
-- [Pasting direct image URL inserts Embed block instead of Image block](https://github.com/WordPress/gutenberg/issues/74734)
+- [Update channel_authorize to reflect that it's restricted like other signing methods](https://github.com/XRPLF/xrpl-dev-portal/issues/3197)
 
-## [nodejs/node](https://github.com/nodejs/node)
+## [CesiumGS/cesium](https://github.com/CesiumGS/cesium)
 
-- [Runtime-deprecate calling digest() on HMAC more than once](https://github.com/nodejs/node/issues/62838)
-- [test_runner: node:coverage ignore comments exclude DA but leave BRDA in lcov output](https://github.com/nodejs/node/issues/61586)
-- [webstreams: narrow `ReadableStreamBYOBRequest.view` to `Uint8Array`](https://github.com/nodejs/node/issues/62952)
-- [crypto,quic: missing NULL checks for OpenSSL allocation functions](https://github.com/nodejs/node/issues/62774)
-- [Cpplint produces false positives for FastApiOptions](https://github.com/nodejs/node/issues/45761)
-- [Transpile TypeScript code inside `node_modules`.](https://github.com/nodejs/node/issues/58429)
-- [Recommend `node`/`default` conditions instead of `require`/`import` as a solution to the dual package hazard](https://github.com/nodejs/node/issues/52174)
+- [DeveloperError: Must define either _workerName or _workerPath for asynchronous geometry.](https://github.com/CesiumGS/cesium/issues/12826)
+- [Ongoing documentation fixes](https://github.com/CesiumGS/cesium/issues/11749)
 
-## [medic/cht-core](https://github.com/medic/cht-core)
+## [stdlib-js/stdlib](https://github.com/stdlib-js/stdlib)
 
-- [Replace `any` types with proper interfaces in small service files](https://github.com/medic/cht-core/issues/10883)
-- [Migrate small Angular templates from structural directives to built-in control flow](https://github.com/medic/cht-core/issues/10882)
-- [Add constants for 'task', 'target', and 'user-settings' document types](https://github.com/medic/cht-core/issues/10548)
-- [Add constant for 'contact' document type](https://github.com/medic/cht-core/issues/10545)
-- [Add constant for 'person' document type](https://github.com/medic/cht-core/issues/10543)
-- [Investigate loading externally hosted media into forms](https://github.com/medic/cht-core/issues/10323)
+- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11958)
+- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11936)
+- [Fix TypeScript declarations lint errors](https://github.com/stdlib-js/stdlib/issues/11896)
+- [Fix broken Markdown link: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about](https://github.com/stdlib-js/stdlib/issues/11868)
+- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11867)
+- [Fix JavaScript lint errors](https://github.com/stdlib-js/stdlib/issues/11784)
+- [[RFC]: Migrate `math/base/special` packages from relative tolerance testing to ULP difference testing (tracking issue)](https://github.com/stdlib-js/stdlib/issues/11352)
 
-## [nodejs/undici](https://github.com/nodejs/undici)
+## [hackforla/tdm-calculator](https://github.com/hackforla/tdm-calculator)
 
-- [interceptors: move signal handling to interceptor](https://github.com/nodejs/undici/issues/3276)
+- [FAQ database: Add content: What happens to my submitted, but not-yet-approved, TDM Plan if the TDM Program Guidelines change?](https://github.com/hackforla/tdm-calculator/issues/3018)
+- [FAQ database: How to Submit a Snapshot](https://github.com/hackforla/tdm-calculator/issues/2754)
+- [FAQ database: Add content: How do I make revisions to my submitted TDM Plan that were requested by LADOT?](https://github.com/hackforla/tdm-calculator/issues/3023)
+- [FAQ database: Add content: I have an approved TDM Plan and my building has a Certificate of Occupancy. How do I modify my TDM Plan?](https://github.com/hackforla/tdm-calculator/issues/3022)
+- [Dev: Update the spelling linter exclusion list with new terms](https://github.com/hackforla/tdm-calculator/issues/3167)
+- [DEV: External links should open consistently across all pages.](https://github.com/hackforla/tdm-calculator/issues/3029)
+- [Bug: field focus on Page 1 is incorrect](https://github.com/hackforla/tdm-calculator/issues/3109)
+- [FAQ database: Add content: How do I revise my proposed TDM Plan while keeping the same version of the Program Guidelines as my original submission?](https://github.com/hackforla/tdm-calculator/issues/3024)
+- [Dev: Update text when there are no results on Submissions page](https://github.com/hackforla/tdm-calculator/issues/3078)
+- [FAQ database: Add content: How can I search and filter my projects](https://github.com/hackforla/tdm-calculator/issues/2744)
+- [Dev: Fix column heading alignment and Date format on Security page](https://github.com/hackforla/tdm-calculator/issues/2580)
+
+## [UltiMafia/Ultimafia](https://github.com/UltiMafia/Ultimafia)
+
+- [feat(game): role marker should allow exact-searches](https://github.com/UltiMafia/Ultimafia/issues/2774)
+
+## [younisdev/dyvix-ui](https://github.com/younisdev/dyvix-ui)
+
+- [[Feature] Add `Warning` and `info` toast types.](https://github.com/younisdev/dyvix-ui/issues/100)
+- [[Chore] Move toast position styles into there own positions.css](https://github.com/younisdev/dyvix-ui/issues/96)
+
+## [q5js/q5.js](https://github.com/q5js/q5.js)
+
+- [Create more MSDF fonts to put in q5's fonts folder](https://github.com/q5js/q5.js/issues/123)
+
+## [carnworkstudios/TAFNE](https://github.com/carnworkstudios/TAFNE)
+
+- [Table style presets (theme picker)](https://github.com/carnworkstudios/TAFNE/issues/7)
+- [Handle Global Undo/Redo across Mode Switches](https://github.com/carnworkstudios/TAFNE/issues/4)
+- [Export Node Graph as SVG/PNG](https://github.com/carnworkstudios/TAFNE/issues/3)
+
+## [OREL-group/Project-Management](https://github.com/OREL-group/Project-Management)
+
+- [Add onboarding welcome screen for new users](https://github.com/OREL-group/Project-Management/issues/216)
+- [make a Start Here guide for plugin setup](https://github.com/OREL-group/Project-Management/issues/123)
+- [reaching out to investors](https://github.com/OREL-group/Project-Management/issues/95)
+- [create a organized database for the prototype](https://github.com/OREL-group/Project-Management/issues/90)
+- [Finalize Design Sprint Objectives](https://github.com/OREL-group/Project-Management/issues/50)
+- [Discover who we need to hire for the project](https://github.com/OREL-group/Project-Management/issues/39)
 
 ## [LOLinDark/StreamerOps](https://github.com/LOLinDark/StreamerOps)
 
@@ -195,25 +237,6 @@ This list gets updated every day at midnight.
 ## [sugarlabs/musicblocks](https://github.com/sugarlabs/musicblocks)
 
 - [Custom Pitch block's pie menu is reversed, no rotation, and no pitch preview](https://github.com/sugarlabs/musicblocks/issues/2255)
-
-## [layer5io/layer5](https://github.com/layer5io/layer5)
-
-- [[Community] Member Profile: Lenox Wiltshire](https://github.com/layer5io/layer5/issues/7700)
-- [[Animation] Animate Meshery Architecture](https://github.com/layer5io/layer5/issues/7661)
-- [Add Meshery Relationships Tutorial to Newcomers page](https://github.com/layer5io/layer5/issues/7696)
-- [Update the structure of pages based on the latest sitemap revision available in Figma](https://github.com/layer5io/layer5/issues/5359)
-- [[Sistent] Add Table component to the Sistent components page](https://github.com/layer5io/layer5/issues/7607)
-- [[Sistent] Add Data Table component to the Sistent components page](https://github.com/layer5io/layer5/issues/7681)
-- [[SEO] First Contentful Paint (FCP): gatsby-plugin-webpack-bundle-analyser-v2](https://github.com/layer5io/layer5/issues/6449)
-- [[Screenshots] Old Screenshots of Meshery Playground needs to be updated](https://github.com/layer5io/layer5/issues/5342)
-- [[Performance] Improve Home Page Performance (layer5.io)](https://github.com/layer5io/layer5/issues/6924)
-- [Update resources and hands-on labs with latest content](https://github.com/layer5io/layer5/issues/6387)
-- [[CI] Create or add to existing workflow: a broken link checker](https://github.com/layer5io/layer5/issues/6407)
-- [[Sistent] Add ClickAwayListener component to the sistent components page](https://github.com/layer5io/layer5/issues/7668)
-- [add animated card](https://github.com/layer5io/layer5/issues/6521)
-- [[Sistent] Add Menu component to the sistent components page](https://github.com/layer5io/layer5/issues/7662)
-- [[Visual Design] New Recognition Badge: Event Evangelist Badge](https://github.com/layer5io/layer5/issues/4809)
-- [Improve styling of categories of models](https://github.com/layer5io/layer5/issues/7593)
 
 ## [OSC/ondemand](https://github.com/OSC/ondemand)
 

--- a/index.html
+++ b/index.html
@@ -1,261 +1,269 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>Good Javascript First Issues</title>
-  <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Good First Issues</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .controls { display: flex; gap: 12px; padding: 16px 0; }
+    .controls button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; cursor: pointer; font-size: 14px; background: #f5f5f5; }
+    .controls button.active { background: #0969da; color: #fff; border-color: #0969da; }
+    .issue.hidden { display: none; }
+    .repo.hidden { display: none; }
+  </style>
 </head>
 <body>
-<h1 id="good-first-issues">Good First Issues</h1>
-<p>This is a list of JavaScript repositories with good first issues for newcomers to open source. Contributions are welcome!</p>
-<p>This list gets updated every day at midnight.</p>
-<h2 id="nextcloud-spreed"><a href="https://github.com/nextcloud/spreed">nextcloud/spreed</a></h2>
-<ul>
-<li><a href="https://github.com/nextcloud/spreed/issues/3518">Go back to autopilot mode if re-clicking selected participant</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/14571">Migrate OCC to InvitationList</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/14570">Migrate addParticipantToRoom to InvitationList</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/14547">Imprint and privacy links in public talk conversations</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/13594">talk couldn&#39;t work after install the “talk_matterbridge”</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/12429">Limit to groups in federated target server breaks federation</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/11857">Reactions notifications when fully subscribed in federated conversations</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/11768">System message shows &quot;guest added user&quot; to a conversation when adding through circle/team</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/11746">Write tests for &quot;Team resources&quot; integration</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/13777">Temporary message added before date separator</a></li>
-<li><a href="https://github.com/nextcloud/spreed/issues/15276">Instant meeting outside of dashboard?</a></li>
-</ul>
-<h2 id="lovelystook-plataforma-de-gesti-n-de-proyectos-estilo-kanban"><a href="https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN">LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN</a></h2>
-<ul>
-<li><a href="https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/3">Revisión de la documentación</a></li>
-<li><a href="https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/2">Sprints por hacer.</a></li>
-</ul>
-<h2 id="heyputer-puter"><a href="https://github.com/HeyPuter/puter">HeyPuter/puter</a></h2>
-<ul>
-<li><a href="https://github.com/HeyPuter/puter/issues/2895">Add support for <code>defaultValue</code> option for <code>puter.ui.setColorPicker</code> in puter app environment</a></li>
-<li><a href="https://github.com/HeyPuter/puter/issues/2894">Add support for <code>defaultValue</code> option for <code>puter.ui.prompt</code> in puter app environment</a></li>
-</ul>
-<h2 id="louislam-uptime-kuma"><a href="https://github.com/louislam/uptime-kuma">louislam/uptime-kuma</a></h2>
-<ul>
-<li><a href="https://github.com/louislam/uptime-kuma/issues/5977">Navbar in mobile view has broken navbar position when on the list tab</a></li>
-<li><a href="https://github.com/louislam/uptime-kuma/issues/4337">[GDPR] Add cookies consent when Google Analytics is Enabled</a></li>
-<li><a href="https://github.com/louislam/uptime-kuma/issues/4304">GameDig Discord Server Monitoring</a></li>
-<li><a href="https://github.com/louislam/uptime-kuma/issues/7242">Pausing a group does not pause the individual monitors of that group</a></li>
-<li><a href="https://github.com/louislam/uptime-kuma/issues/5670">Password Reset via CLI does not work on Embedded MariaDB</a></li>
-</ul>
-<h2 id="meshery-meshery-io"><a href="https://github.com/meshery/meshery.io">meshery/meshery.io</a></h2>
-<ul>
-<li><a href="https://github.com/meshery/meshery.io/issues/2661">GSoC Program 2026: Add hyperlink to Meshery org</a></li>
-</ul>
-<h2 id="vercel-next-js"><a href="https://github.com/vercel/next.js">vercel/next.js</a></h2>
-<ul>
-<li><a href="https://github.com/vercel/next.js/issues/20924">Misleading &quot;next-head-count is missing&quot; error for invalid head tags</a></li>
-<li><a href="https://github.com/vercel/next.js/issues/38863">POST request succeeds for pages with next dev</a></li>
-<li><a href="https://github.com/vercel/next.js/issues/41281">Inconsistent Error Messaging / Handling in getStaticPaths</a></li>
-<li><a href="https://github.com/vercel/next.js/issues/42846">Parameter on <code>AppType</code> is used incorrectly</a></li>
-<li><a href="https://github.com/vercel/next.js/issues/53473"><code>@next/next/no-html-link-for-pages</code> rule does not work with <code>pageExtensions</code></a></li>
-</ul>
-<h2 id="harperfast-harper"><a href="https://github.com/HarperFast/harper">HarperFast/harper</a></h2>
-<ul>
-<li><a href="https://github.com/HarperFast/harper/issues/307">Update TLS privateKey to use relative path and update tests</a></li>
-<li><a href="https://github.com/HarperFast/harper/issues/145">Convert harper logger module to TypeScript</a></li>
-</ul>
-<h2 id="cdxgen-cdxgen"><a href="https://github.com/cdxgen/cdxgen">cdxgen/cdxgen</a></h2>
-<ul>
-<li><a href="https://github.com/cdxgen/cdxgen/issues/599">Update readme and docs regarding optional plugins</a></li>
-</ul>
-<h2 id="xrplf-xrpl-dev-portal"><a href="https://github.com/XRPLF/xrpl-dev-portal">XRPLF/xrpl-dev-portal</a></h2>
-<ul>
-<li><a href="https://github.com/XRPLF/xrpl-dev-portal/issues/3197">Update channel_authorize to reflect that it&#39;s restricted like other signing methods</a></li>
-</ul>
-<h2 id="stdlib-js-stdlib"><a href="https://github.com/stdlib-js/stdlib">stdlib-js/stdlib</a></h2>
-<ul>
-<li><a href="https://github.com/stdlib-js/stdlib/issues/11936">Fix JavaScript lint errors</a></li>
-<li><a href="https://github.com/stdlib-js/stdlib/issues/11896">Fix TypeScript declarations lint errors</a></li>
-<li><a href="https://github.com/stdlib-js/stdlib/issues/11868">Fix broken Markdown link: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about</a></li>
-<li><a href="https://github.com/stdlib-js/stdlib/issues/11867">Fix JavaScript lint errors</a></li>
-<li><a href="https://github.com/stdlib-js/stdlib/issues/11784">Fix JavaScript lint errors</a></li>
-<li><a href="https://github.com/stdlib-js/stdlib/issues/11352">[RFC]: Migrate <code>math/base/special</code> packages from relative tolerance testing to ULP difference testing (tracking issue)</a></li>
-</ul>
-<h2 id="hackforla-tdm-calculator"><a href="https://github.com/hackforla/tdm-calculator">hackforla/tdm-calculator</a></h2>
-<ul>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3022">FAQ database: Add content: I have an approved TDM Plan and my building has a Certificate of Occupancy. How do I modify my TDM Plan?</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3018">FAQ database: Add content: What happens to my submitted, but not-yet-approved, TDM Plan if the TDM Program Guidelines change?</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3167">Dev: Update the spelling linter exclusion list with new terms</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3029">DEV: External links should open consistently across all pages.</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3109">Bug: field focus on Page 1 is incorrect</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/2754">FAQ database: How to Submit a Snapshot</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3024">FAQ database: Add content: How do I revise my proposed TDM Plan while keeping the same version of the Program Guidelines as my original submission?</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3023">FAQ database: Add content: How do I make revisions to my submitted TDM Plan that were requested by LADOT?</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/3078">Dev: Update text when there are no results on Submissions page</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/2744">FAQ database: Add content: How can I search and filter my projects</a></li>
-<li><a href="https://github.com/hackforla/tdm-calculator/issues/2580">Dev: Fix column heading alignment and Date format on Security page</a></li>
-</ul>
-<h2 id="ultimafia-ultimafia"><a href="https://github.com/UltiMafia/Ultimafia">UltiMafia/Ultimafia</a></h2>
-<ul>
-<li><a href="https://github.com/UltiMafia/Ultimafia/issues/2774">feat(game): role marker should allow exact-searches</a></li>
-</ul>
-<h2 id="younisdev-dyvix-ui"><a href="https://github.com/younisdev/dyvix-ui">younisdev/dyvix-ui</a></h2>
-<ul>
-<li><a href="https://github.com/younisdev/dyvix-ui/issues/100">[Feature] Add <code>Warning</code> and <code>info</code> toast types.</a></li>
-<li><a href="https://github.com/younisdev/dyvix-ui/issues/96">[Chore] Move toast position styles into there own positions.css</a></li>
-</ul>
-<h2 id="q5js-q5-js"><a href="https://github.com/q5js/q5.js">q5js/q5.js</a></h2>
-<ul>
-<li><a href="https://github.com/q5js/q5.js/issues/123">Create more MSDF fonts to put in q5&#39;s fonts folder</a></li>
-</ul>
-<h2 id="carnworkstudios-tafne"><a href="https://github.com/carnworkstudios/TAFNE">carnworkstudios/TAFNE</a></h2>
-<ul>
-<li><a href="https://github.com/carnworkstudios/TAFNE/issues/7">Table style presets (theme picker)</a></li>
-<li><a href="https://github.com/carnworkstudios/TAFNE/issues/4">Handle Global Undo/Redo across Mode Switches</a></li>
-<li><a href="https://github.com/carnworkstudios/TAFNE/issues/3">Export Node Graph as SVG/PNG</a></li>
-</ul>
-<h2 id="orel-group-project-management"><a href="https://github.com/OREL-group/Project-Management">OREL-group/Project-Management</a></h2>
-<ul>
-<li><a href="https://github.com/OREL-group/Project-Management/issues/216">Add onboarding welcome screen for new users</a></li>
-<li><a href="https://github.com/OREL-group/Project-Management/issues/123">make a Start Here guide for plugin setup</a></li>
-<li><a href="https://github.com/OREL-group/Project-Management/issues/95">reaching out to investors</a></li>
-<li><a href="https://github.com/OREL-group/Project-Management/issues/90">create a organized database for the prototype</a></li>
-<li><a href="https://github.com/OREL-group/Project-Management/issues/50">Finalize Design Sprint Objectives</a></li>
-<li><a href="https://github.com/OREL-group/Project-Management/issues/39">Discover who we need to hire for the project</a></li>
-</ul>
-<h2 id="pipedreamhq-pipedream"><a href="https://github.com/PipedreamHQ/pipedream">PipedreamHQ/pipedream</a></h2>
-<ul>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20754">[ACTION] Alaiko / Zenfulfilment</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20777">[ACTION] openai-analyze-image-content: support configurable model (gpt-4.1, gpt-5, etc.)</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20790">[ACTION] Create item in Zoho Inventory</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20789">[ACTION] HubSpot Meeting Scheduler APIs</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20787">[ACTION] Apollo.io Search APIs</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20431">[ACTION] Remove Specific Label Function in Pipedrive</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20778">[ACTION] Zoho Desk - List Ticket Fields, List Departments</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20773">[ACTION]</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20703">[ACTION] Huntress new actions</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20743">[ACTION] [App] Ringba — request for additional pre-built components</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20750">[ACTIONS] Trolley - Add core actions for recipient and payout workflows</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20719">[ACTION] Databricks - Feature parity with the api key version</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20762">[ACTION] MEWS get bills and fetch rates</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20688">[ACTION] Statuspage - Fetch Active Incidents, Fetch Components, and Create/update maintenances</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20623">Tools for nexudus mcp</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20659">[ACTION]</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20684">[ACTION] Shopify - get tracking</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20357">[ACTION] teamleader update ticket</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20554">[ACTION] New Moodle actions</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20510">[components] Hedy</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20536">[ACTION] Microsoft teams upload image affordance</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20534">[ACTION] Hiver new actions</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20537">[ACTION] Simplify Notion upload image affordance</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20599">[ACTION] New Lever Actions</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/14309">[TRIGGER] Discord new messages in thread</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/15367">[shopify files upload] [Shopify Files section under Content Menu]</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/15378">[FEATURE] Update Runware integration</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/16656">[TRIGGER] watch a row</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/16725">New Apollo recording available</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/15515">[ACTIONS] Procore - Direct Costs API</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/16697">[ACTION] notion - update page</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/18821">[ACTION] Add CoinAPI MCP Server integration</a></li>
-<li><a href="https://github.com/PipedreamHQ/pipedream/issues/20027">[ACTION] Get DPD parcel status</a></li>
-</ul>
-<h2 id="wordpress-gutenberg"><a href="https://github.com/WordPress/gutenberg">WordPress/gutenberg</a></h2>
-<ul>
-<li><a href="https://github.com/WordPress/gutenberg/issues/64104">Patterns from the pattern directory do not show if placed in a template</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/76579">Original PRs may not be tagged properly when a manual cherry-pick is performed.</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/72505">Page jumps away when trying to edit an anchor link</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/72265">Custom font upload not working</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/53555">Since 6.3, the display ratio of images is broken when the size of the Image Block is specified.</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/12101">Meta boxes: update core styles to match Gutenberg&#39;s</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/22890">Code Quality: Refactor all React class components to functional components using hooks</a></li>
-<li><a href="https://github.com/WordPress/gutenberg/issues/74734">Pasting direct image URL inserts Embed block instead of Image block</a></li>
-</ul>
-<h2 id="nodejs-node"><a href="https://github.com/nodejs/node">nodejs/node</a></h2>
-<ul>
-<li><a href="https://github.com/nodejs/node/issues/62838">Runtime-deprecate calling digest() on HMAC more than once</a></li>
-<li><a href="https://github.com/nodejs/node/issues/61586">test_runner: node:coverage ignore comments exclude DA but leave BRDA in lcov output</a></li>
-<li><a href="https://github.com/nodejs/node/issues/62952">webstreams: narrow <code>ReadableStreamBYOBRequest.view</code> to <code>Uint8Array</code></a></li>
-<li><a href="https://github.com/nodejs/node/issues/62774">crypto,quic: missing NULL checks for OpenSSL allocation functions</a></li>
-<li><a href="https://github.com/nodejs/node/issues/45761">Cpplint produces false positives for FastApiOptions</a></li>
-<li><a href="https://github.com/nodejs/node/issues/58429">Transpile TypeScript code inside <code>node_modules</code>.</a></li>
-<li><a href="https://github.com/nodejs/node/issues/52174">Recommend <code>node</code>/<code>default</code> conditions instead of <code>require</code>/<code>import</code> as a solution to the dual package hazard</a></li>
-</ul>
-<h2 id="medic-cht-core"><a href="https://github.com/medic/cht-core">medic/cht-core</a></h2>
-<ul>
-<li><a href="https://github.com/medic/cht-core/issues/10883">Replace <code>any</code> types with proper interfaces in small service files</a></li>
-<li><a href="https://github.com/medic/cht-core/issues/10882">Migrate small Angular templates from structural directives to built-in control flow</a></li>
-<li><a href="https://github.com/medic/cht-core/issues/10548">Add constants for &#39;task&#39;, &#39;target&#39;, and &#39;user-settings&#39; document types</a></li>
-<li><a href="https://github.com/medic/cht-core/issues/10545">Add constant for &#39;contact&#39; document type</a></li>
-<li><a href="https://github.com/medic/cht-core/issues/10543">Add constant for &#39;person&#39; document type</a></li>
-<li><a href="https://github.com/medic/cht-core/issues/10323">Investigate loading externally hosted media into forms</a></li>
-</ul>
-<h2 id="nodejs-undici"><a href="https://github.com/nodejs/undici">nodejs/undici</a></h2>
-<ul>
-<li><a href="https://github.com/nodejs/undici/issues/3276">interceptors: move signal handling to interceptor</a></li>
-</ul>
-<h2 id="lolindark-streamerops"><a href="https://github.com/LOLinDark/StreamerOps">LOLinDark/StreamerOps</a></h2>
-<ul>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/12">bug: hardcoded referral code placeholder in WelcomeOnline.jsx</a></li>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/14">enhancement: add PropTypes validation to shared UI components</a></li>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/13">chore: migrate wiki-seed docs from repo into the GitHub wiki</a></li>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/11">docs: fill in Architecture section in documentation/README.md</a></li>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/10">chore: add CONTRIBUTING.md with contributor guidelines</a></li>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/9">chore: add a LICENSE file to the repository</a></li>
-<li><a href="https://github.com/LOLinDark/StreamerOps/issues/8">docs: replace OmniCore references with StreamerOps in documentation</a></li>
-</ul>
-<h2 id="sugarlabs-musicblocks"><a href="https://github.com/sugarlabs/musicblocks">sugarlabs/musicblocks</a></h2>
-<ul>
-<li><a href="https://github.com/sugarlabs/musicblocks/issues/2255">Custom Pitch block&#39;s pie menu is reversed, no rotation, and no pitch preview</a></li>
-</ul>
-<h2 id="layer5io-layer5"><a href="https://github.com/layer5io/layer5">layer5io/layer5</a></h2>
-<ul>
-<li><a href="https://github.com/layer5io/layer5/issues/7700">[Community] Member Profile: Lenox Wiltshire</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7661">[Animation] Animate Meshery Architecture</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7696">Add Meshery Relationships Tutorial to Newcomers page</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/5359">Update the structure of pages based on the latest sitemap revision available in Figma</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7607">[Sistent] Add Table component to the Sistent components page</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7681">[Sistent] Add Data Table component to the Sistent components page</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/6449">[SEO] First Contentful Paint (FCP): gatsby-plugin-webpack-bundle-analyser-v2</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/5342">[Screenshots] Old Screenshots of Meshery Playground needs to be updated</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/6924">[Performance] Improve Home Page Performance (layer5.io)</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/6387">Update resources and hands-on labs with latest content</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/6407">[CI] Create or add to existing workflow: a broken link checker</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7668">[Sistent] Add ClickAwayListener component to the sistent components page</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/6521">add animated card</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7662">[Sistent] Add Menu component to the sistent components page</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/4809">[Visual Design] New Recognition Badge: Event Evangelist Badge</a></li>
-<li><a href="https://github.com/layer5io/layer5/issues/7593">Improve styling of categories of models</a></li>
-</ul>
-<h2 id="osc-ondemand"><a href="https://github.com/OSC/ondemand">OSC/ondemand</a></h2>
-<ul>
-<li><a href="https://github.com/OSC/ondemand/issues/5293">Don&#39;t compose strings with internationalizations</a></li>
-<li><a href="https://github.com/OSC/ondemand/issues/866">default MOTD</a></li>
-<li><a href="https://github.com/OSC/ondemand/issues/132">ActiveJobs: Show job submission time.</a></li>
-</ul>
-<h2 id="dbt-labs-docs-getdbt-com"><a href="https://github.com/dbt-labs/docs.getdbt.com">dbt-labs/docs.getdbt.com</a></h2>
-<ul>
-<li><a href="https://github.com/dbt-labs/docs.getdbt.com/issues/8908"><code>--resource-type</code> is used by more than just <code>ls</code></a></li>
-<li><a href="https://github.com/dbt-labs/docs.getdbt.com/issues/8584">fail fast docs only mentions <code>run</code> but works for <code>build</code> and <code>test</code> too</a></li>
-<li><a href="https://github.com/dbt-labs/docs.getdbt.com/issues/5651">[Core] Configurability of the timestamps in logs</a></li>
-</ul>
-<h2 id="badges-shields"><a href="https://github.com/badges/shields">badges/shields</a></h2>
-<ul>
-<li><a href="https://github.com/badges/shields/issues/7581">Badge request: SDKMAN</a></li>
-<li><a href="https://github.com/badges/shields/issues/10162">Azure DevOps - Build Badge - PAT Token not used on private projects</a></li>
-</ul>
-<h2 id="wikispeedruns-wikipedia-speedruns"><a href="https://github.com/wikispeedruns/wikipedia-speedruns">wikispeedruns/wikipedia-speedruns</a></h2>
-<ul>
-<li><a href="https://github.com/wikispeedruns/wikipedia-speedruns/issues/625">Anchor tags on homepage doesn&#39;t highlight the tab for that part of the page.</a></li>
-</ul>
-<h2 id="google-closure-compiler"><a href="https://github.com/google/closure-compiler">google/closure-compiler</a></h2>
-<ul>
-<li><a href="https://github.com/google/closure-compiler/issues/4046">Array constructor with length is not eliminated</a></li>
-</ul>
-<h2 id="oss-slu-digitalbonebox"><a href="https://github.com/oss-slu/DigitalBoneBox">oss-slu/DigitalBoneBox</a></h2>
-<ul>
-<li><a href="https://github.com/oss-slu/DigitalBoneBox/issues/274">Remove unused functions</a></li>
-<li><a href="https://github.com/oss-slu/DigitalBoneBox/issues/233">Label toggle</a></li>
-</ul>
-<h2 id="sabbah13-cowork-tasks"><a href="https://github.com/sabbah13/cowork-tasks">sabbah13/cowork-tasks</a></h2>
-<ul>
-<li><a href="https://github.com/sabbah13/cowork-tasks/issues/30">perf: lazy-load card detail panel</a></li>
-<li><a href="https://github.com/sabbah13/cowork-tasks/issues/32">a11y: keyboard navigation audit + fixes</a></li>
-<li><a href="https://github.com/sabbah13/cowork-tasks/issues/31">i18n: scaffolding for German and Japanese</a></li>
-<li><a href="https://github.com/sabbah13/cowork-tasks/issues/29">feat: snooze-until-tomorrow card action</a></li>
-<li><a href="https://github.com/sabbah13/cowork-tasks/issues/28">docs: &#39;first 5 minutes&#39; walkthrough with screenshots</a></li>
-</ul>
+  <h1>Good First Issues</h1>
+  <p>JavaScript repositories with good first issues. Updated daily.</p>
+  <div class="controls">
+    <button id="btn-hide-old">Hide issues inactive for 7+ days</button>
+    <button id="btn-sort-recent">Sort by most recent</button>
+  </div>
+  <div id="issues-container">
+  <section class="repo" data-index="0" data-newest="1775406388000"><h2><a href="https://github.com/naimkatiman/continuous-improvement" target="_blank" rel="noreferrer">naimkatiman/continuous-improvement</a></h2><ul><li class="issue stale" data-updated="2026-04-05T16:26:28.000Z" data-index="0"><a href="https://github.com/naimkatiman/continuous-improvement/issues/21" target="_blank" rel="noreferrer">Create 'Law of the Week' content series for X/Twitter</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:25:35.000Z" data-index="1"><a href="https://github.com/naimkatiman/continuous-improvement/issues/11" target="_blank" rel="noreferrer">Write blog post: 'Why your AI agent keeps lying about being done'</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:25:30.000Z" data-index="2"><a href="https://github.com/naimkatiman/continuous-improvement/issues/10" target="_blank" rel="noreferrer">Record a 2-min before/after demo video</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:25:25.000Z" data-index="3"><a href="https://github.com/naimkatiman/continuous-improvement/issues/9" target="_blank" rel="noreferrer">Add full Gemini CLI integration (hooks + installer)</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:25:21.000Z" data-index="4"><a href="https://github.com/naimkatiman/continuous-improvement/issues/8" target="_blank" rel="noreferrer">Submit to awesome-agent-skills listing</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:25:15.000Z" data-index="5"><a href="https://github.com/naimkatiman/continuous-improvement/issues/7" target="_blank" rel="noreferrer">Fix version badge mismatch in README</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:25:00.000Z" data-index="6"><a href="https://github.com/naimkatiman/continuous-improvement/issues/5" target="_blank" rel="noreferrer">Improve observe.sh hook with configurable triggers</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:24:58.000Z" data-index="7"><a href="https://github.com/naimkatiman/continuous-improvement/issues/3" target="_blank" rel="noreferrer">Create CONTRIBUTING.md guide</a></li>
+<li class="issue stale" data-updated="2026-04-05T16:24:56.000Z" data-index="8"><a href="https://github.com/naimkatiman/continuous-improvement/issues/2" target="_blank" rel="noreferrer">Add unit tests for install.mjs</a></li>
+</ul></section>
+<section class="repo" data-index="1" data-newest="1776087038000"><h2><a href="https://github.com/cdxgen/cdxgen" target="_blank" rel="noreferrer">cdxgen/cdxgen</a></h2><ul><li class="issue stale" data-updated="2026-04-13T13:30:38.000Z" data-index="0"><a href="https://github.com/cdxgen/cdxgen/issues/599" target="_blank" rel="noreferrer">Update readme and docs regarding optional plugins</a></li>
+</ul></section>
+<section class="repo" data-index="2" data-newest="1777878233000"><h2><a href="https://github.com/WordPress/gutenberg" target="_blank" rel="noreferrer">WordPress/gutenberg</a></h2><ul><li class="issue " data-updated="2026-05-04T07:03:53.000Z" data-index="0"><a href="https://github.com/WordPress/gutenberg/issues/64104" target="_blank" rel="noreferrer">Patterns from the pattern directory do not show if placed in a template</a></li>
+<li class="issue " data-updated="2026-05-02T19:52:24.000Z" data-index="1"><a href="https://github.com/WordPress/gutenberg/issues/76579" target="_blank" rel="noreferrer">Original PRs may not be tagged properly when a manual cherry-pick is performed.</a></li>
+<li class="issue stale" data-updated="2026-04-28T13:04:22.000Z" data-index="2"><a href="https://github.com/WordPress/gutenberg/issues/72505" target="_blank" rel="noreferrer">Page jumps away when trying to edit an anchor link</a></li>
+<li class="issue stale" data-updated="2026-04-15T09:17:38.000Z" data-index="3"><a href="https://github.com/WordPress/gutenberg/issues/72265" target="_blank" rel="noreferrer">Custom font upload not working</a></li>
+<li class="issue stale" data-updated="2026-04-15T05:27:05.000Z" data-index="4"><a href="https://github.com/WordPress/gutenberg/issues/53555" target="_blank" rel="noreferrer">Since 6.3, the display ratio of images is broken when the size of the Image Block is specified.</a></li>
+<li class="issue stale" data-updated="2026-04-09T17:33:11.000Z" data-index="5"><a href="https://github.com/WordPress/gutenberg/issues/12101" target="_blank" rel="noreferrer">Meta boxes: update core styles to match Gutenberg's</a></li>
+<li class="issue stale" data-updated="2026-04-09T05:36:12.000Z" data-index="6"><a href="https://github.com/WordPress/gutenberg/issues/22890" target="_blank" rel="noreferrer">Code Quality: Refactor all React class components to functional components using hooks</a></li>
+<li class="issue stale" data-updated="2026-04-09T05:18:27.000Z" data-index="7"><a href="https://github.com/WordPress/gutenberg/issues/74734" target="_blank" rel="noreferrer">Pasting direct image URL inserts Embed block instead of Image block</a></li>
+</ul></section>
+<section class="repo" data-index="3" data-newest="1777563374000"><h2><a href="https://github.com/vercel/next.js" target="_blank" rel="noreferrer">vercel/next.js</a></h2><ul><li class="issue " data-updated="2026-04-30T15:36:14.000Z" data-index="0"><a href="https://github.com/vercel/next.js/issues/20924" target="_blank" rel="noreferrer">Misleading "next-head-count is missing" error for invalid head tags</a></li>
+<li class="issue " data-updated="2026-04-30T15:35:55.000Z" data-index="1"><a href="https://github.com/vercel/next.js/issues/38863" target="_blank" rel="noreferrer">POST request succeeds for pages with next dev</a></li>
+<li class="issue " data-updated="2026-04-30T15:35:39.000Z" data-index="2"><a href="https://github.com/vercel/next.js/issues/41281" target="_blank" rel="noreferrer">Inconsistent Error Messaging / Handling in getStaticPaths</a></li>
+<li class="issue " data-updated="2026-04-30T15:35:21.000Z" data-index="3"><a href="https://github.com/vercel/next.js/issues/42846" target="_blank" rel="noreferrer">Parameter on `AppType` is used incorrectly</a></li>
+<li class="issue " data-updated="2026-04-30T15:35:19.000Z" data-index="4"><a href="https://github.com/vercel/next.js/issues/53473" target="_blank" rel="noreferrer">`@next/next/no-html-link-for-pages` rule does not work with `pageExtensions`</a></li>
+</ul></section>
+<section class="repo" data-index="4" data-newest="1777918424000"><h2><a href="https://github.com/nodejs/node" target="_blank" rel="noreferrer">nodejs/node</a></h2><ul><li class="issue " data-updated="2026-05-04T18:13:44.000Z" data-index="0"><a href="https://github.com/nodejs/node/issues/62838" target="_blank" rel="noreferrer">Runtime-deprecate calling digest() on HMAC more than once</a></li>
+<li class="issue " data-updated="2026-05-02T20:50:14.000Z" data-index="1"><a href="https://github.com/nodejs/node/issues/61586" target="_blank" rel="noreferrer">test_runner: node:coverage ignore comments exclude DA but leave BRDA in lcov output</a></li>
+<li class="issue " data-updated="2026-05-02T14:38:30.000Z" data-index="2"><a href="https://github.com/nodejs/node/issues/62952" target="_blank" rel="noreferrer">webstreams: narrow `ReadableStreamBYOBRequest.view` to `Uint8Array`</a></li>
+<li class="issue stale" data-updated="2026-04-28T18:30:52.000Z" data-index="3"><a href="https://github.com/nodejs/node/issues/62774" target="_blank" rel="noreferrer">crypto,quic: missing NULL checks for OpenSSL allocation functions</a></li>
+<li class="issue stale" data-updated="2026-04-28T18:27:29.000Z" data-index="4"><a href="https://github.com/nodejs/node/issues/45761" target="_blank" rel="noreferrer">Cpplint produces false positives for FastApiOptions</a></li>
+<li class="issue stale" data-updated="2026-04-15T12:03:11.000Z" data-index="5"><a href="https://github.com/nodejs/node/issues/58429" target="_blank" rel="noreferrer">Transpile TypeScript code inside `node_modules`.</a></li>
+<li class="issue stale" data-updated="2026-04-07T09:48:43.000Z" data-index="6"><a href="https://github.com/nodejs/node/issues/52174" target="_blank" rel="noreferrer">Recommend `node`/`default` conditions instead of `require`/`import` as a solution to the dual package hazard</a></li>
+</ul></section>
+<section class="repo" data-index="5" data-newest="1778031260000"><h2><a href="https://github.com/HarperFast/harper" target="_blank" rel="noreferrer">HarperFast/harper</a></h2><ul><li class="issue " data-updated="2026-05-06T01:34:20.000Z" data-index="0"><a href="https://github.com/HarperFast/harper/issues/297" target="_blank" rel="noreferrer">Incorrect logic for matching index.html</a></li>
+<li class="issue stale" data-updated="2026-04-17T19:11:40.000Z" data-index="1"><a href="https://github.com/HarperFast/harper/issues/307" target="_blank" rel="noreferrer">Update TLS privateKey to use relative path and update tests</a></li>
+<li class="issue stale" data-updated="2026-04-17T19:10:54.000Z" data-index="2"><a href="https://github.com/HarperFast/harper/issues/145" target="_blank" rel="noreferrer">Convert harper logger module to TypeScript</a></li>
+</ul></section>
+<section class="repo" data-index="6" data-newest="1776109667000"><h2><a href="https://github.com/nextcloud/tables" target="_blank" rel="noreferrer">nextcloud/tables</a></h2><ul><li class="issue stale" data-updated="2026-04-13T19:47:47.000Z" data-index="0"><a href="https://github.com/nextcloud/tables/issues/2478" target="_blank" rel="noreferrer">descriptions of the views missing upon import</a></li>
+</ul></section>
+<section class="repo" data-index="7" data-newest="1777878779000"><h2><a href="https://github.com/medic/cht-core" target="_blank" rel="noreferrer">medic/cht-core</a></h2><ul><li class="issue " data-updated="2026-05-04T07:12:59.000Z" data-index="0"><a href="https://github.com/medic/cht-core/issues/10883" target="_blank" rel="noreferrer">Replace `any` types with proper interfaces in small service files</a></li>
+<li class="issue stale" data-updated="2026-04-26T11:04:18.000Z" data-index="1"><a href="https://github.com/medic/cht-core/issues/10882" target="_blank" rel="noreferrer">Migrate small Angular templates from structural directives to built-in control flow</a></li>
+<li class="issue stale" data-updated="2026-04-23T12:27:17.000Z" data-index="2"><a href="https://github.com/medic/cht-core/issues/10548" target="_blank" rel="noreferrer">Add constants for 'task', 'target', and 'user-settings' document types</a></li>
+<li class="issue stale" data-updated="2026-04-16T14:51:21.000Z" data-index="3"><a href="https://github.com/medic/cht-core/issues/10545" target="_blank" rel="noreferrer">Add constant for 'contact' document type</a></li>
+<li class="issue stale" data-updated="2026-04-16T14:50:07.000Z" data-index="4"><a href="https://github.com/medic/cht-core/issues/10543" target="_blank" rel="noreferrer">Add constant for 'person' document type</a></li>
+<li class="issue stale" data-updated="2026-04-16T13:55:59.000Z" data-index="5"><a href="https://github.com/medic/cht-core/issues/10323" target="_blank" rel="noreferrer">Investigate loading externally hosted media into forms</a></li>
+</ul></section>
+<section class="repo" data-index="8" data-newest="1777917286000"><h2><a href="https://github.com/meshery/meshery.io" target="_blank" rel="noreferrer">meshery/meshery.io</a></h2><ul><li class="issue " data-updated="2026-05-04T17:54:46.000Z" data-index="0"><a href="https://github.com/meshery/meshery.io/issues/2661" target="_blank" rel="noreferrer">GSoC Program 2026: Add hyperlink to Meshery org</a></li>
+</ul></section>
+<section class="repo" data-index="9" data-newest="1776307822000"><h2><a href="https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN" target="_blank" rel="noreferrer">LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN</a></h2><ul><li class="issue stale" data-updated="2026-04-16T02:50:22.000Z" data-index="0"><a href="https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/3" target="_blank" rel="noreferrer">Revisión de la documentación</a></li>
+<li class="issue stale" data-updated="2026-04-16T02:43:28.000Z" data-index="1"><a href="https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/2" target="_blank" rel="noreferrer">Sprints por hacer.</a></li>
+</ul></section>
+<section class="repo" data-index="10" data-newest="1777945661000"><h2><a href="https://github.com/HeyPuter/puter" target="_blank" rel="noreferrer">HeyPuter/puter</a></h2><ul><li class="issue " data-updated="2026-05-05T01:47:41.000Z" data-index="0"><a href="https://github.com/HeyPuter/puter/issues/2895" target="_blank" rel="noreferrer">Add support for `defaultValue` option for `puter.ui.setColorPicker` in puter app environment</a></li>
+<li class="issue " data-updated="2026-05-05T01:47:26.000Z" data-index="1"><a href="https://github.com/HeyPuter/puter/issues/2894" target="_blank" rel="noreferrer">Add support for `defaultValue` option for `puter.ui.prompt` in puter app environment</a></li>
+</ul></section>
+<section class="repo" data-index="11" data-newest="1778035373000"><h2><a href="https://github.com/layer5io/layer5" target="_blank" rel="noreferrer">layer5io/layer5</a></h2><ul><li class="issue " data-updated="2026-05-06T02:42:53.000Z" data-index="0"><a href="https://github.com/layer5io/layer5/issues/7700" target="_blank" rel="noreferrer">[Community] Member Profile: Lenox Wiltshire</a></li>
+<li class="issue " data-updated="2026-05-04T20:49:50.000Z" data-index="1"><a href="https://github.com/layer5io/layer5/issues/7661" target="_blank" rel="noreferrer">[Animation] Animate Meshery Architecture</a></li>
+<li class="issue " data-updated="2026-05-04T16:19:10.000Z" data-index="2"><a href="https://github.com/layer5io/layer5/issues/7696" target="_blank" rel="noreferrer">Add Meshery Relationships Tutorial to Newcomers page</a></li>
+<li class="issue " data-updated="2026-05-03T18:19:23.000Z" data-index="3"><a href="https://github.com/layer5io/layer5/issues/5359" target="_blank" rel="noreferrer">Update the structure of pages based on the latest sitemap revision available in Figma</a></li>
+<li class="issue " data-updated="2026-05-02T07:28:21.000Z" data-index="4"><a href="https://github.com/layer5io/layer5/issues/7607" target="_blank" rel="noreferrer">[Sistent] Add Table component to the Sistent components page</a></li>
+<li class="issue " data-updated="2026-05-01T22:48:52.000Z" data-index="5"><a href="https://github.com/layer5io/layer5/issues/7681" target="_blank" rel="noreferrer">[Sistent] Add Data Table component to the Sistent components page</a></li>
+<li class="issue " data-updated="2026-05-01T16:00:43.000Z" data-index="6"><a href="https://github.com/layer5io/layer5/issues/6449" target="_blank" rel="noreferrer">[SEO] First Contentful Paint (FCP): gatsby-plugin-webpack-bundle-analyser-v2</a></li>
+<li class="issue " data-updated="2026-04-30T19:21:35.000Z" data-index="7"><a href="https://github.com/layer5io/layer5/issues/5342" target="_blank" rel="noreferrer">[Screenshots] Old Screenshots of Meshery Playground needs to be updated</a></li>
+<li class="issue " data-updated="2026-04-30T09:33:04.000Z" data-index="8"><a href="https://github.com/layer5io/layer5/issues/6924" target="_blank" rel="noreferrer">[Performance] Improve Home Page Performance (layer5.io)</a></li>
+<li class="issue " data-updated="2026-04-29T15:15:57.000Z" data-index="9"><a href="https://github.com/layer5io/layer5/issues/6387" target="_blank" rel="noreferrer">Update resources and hands-on labs with latest content</a></li>
+<li class="issue " data-updated="2026-04-29T13:59:37.000Z" data-index="10"><a href="https://github.com/layer5io/layer5/issues/6407" target="_blank" rel="noreferrer">[CI] Create or add to existing workflow: a broken link checker</a></li>
+<li class="issue " data-updated="2026-04-29T10:50:32.000Z" data-index="11"><a href="https://github.com/layer5io/layer5/issues/7668" target="_blank" rel="noreferrer">[Sistent] Add ClickAwayListener component to the sistent components page</a></li>
+<li class="issue stale" data-updated="2026-04-28T15:00:36.000Z" data-index="12"><a href="https://github.com/layer5io/layer5/issues/6521" target="_blank" rel="noreferrer">add animated card</a></li>
+<li class="issue stale" data-updated="2026-04-27T13:56:09.000Z" data-index="13"><a href="https://github.com/layer5io/layer5/issues/7662" target="_blank" rel="noreferrer">[Sistent] Add Menu component to the sistent components page</a></li>
+<li class="issue stale" data-updated="2026-04-25T11:50:58.000Z" data-index="14"><a href="https://github.com/layer5io/layer5/issues/4809" target="_blank" rel="noreferrer">[Visual Design] New Recognition Badge: Event Evangelist Badge</a></li>
+<li class="issue stale" data-updated="2026-04-25T06:48:09.000Z" data-index="15"><a href="https://github.com/layer5io/layer5/issues/7593" target="_blank" rel="noreferrer">Improve styling of categories of models</a></li>
+</ul></section>
+<section class="repo" data-index="12" data-newest="1777922251000"><h2><a href="https://github.com/nextcloud/spreed" target="_blank" rel="noreferrer">nextcloud/spreed</a></h2><ul><li class="issue " data-updated="2026-05-04T19:17:31.000Z" data-index="0"><a href="https://github.com/nextcloud/spreed/issues/3518" target="_blank" rel="noreferrer">Go back to autopilot mode if re-clicking selected participant</a></li>
+<li class="issue " data-updated="2026-05-04T19:15:38.000Z" data-index="1"><a href="https://github.com/nextcloud/spreed/issues/14571" target="_blank" rel="noreferrer">Migrate OCC to InvitationList</a></li>
+<li class="issue " data-updated="2026-05-04T19:15:38.000Z" data-index="2"><a href="https://github.com/nextcloud/spreed/issues/14570" target="_blank" rel="noreferrer">Migrate addParticipantToRoom to InvitationList</a></li>
+<li class="issue " data-updated="2026-05-04T19:15:37.000Z" data-index="3"><a href="https://github.com/nextcloud/spreed/issues/14547" target="_blank" rel="noreferrer">Imprint and privacy links in public talk conversations</a></li>
+<li class="issue " data-updated="2026-04-30T12:44:29.000Z" data-index="4"><a href="https://github.com/nextcloud/spreed/issues/13594" target="_blank" rel="noreferrer">talk couldn't work after install the “talk_matterbridge”</a></li>
+<li class="issue " data-updated="2026-04-30T12:44:10.000Z" data-index="5"><a href="https://github.com/nextcloud/spreed/issues/12429" target="_blank" rel="noreferrer">Limit to groups in federated target server breaks federation</a></li>
+<li class="issue " data-updated="2026-04-30T12:44:04.000Z" data-index="6"><a href="https://github.com/nextcloud/spreed/issues/11857" target="_blank" rel="noreferrer">Reactions notifications when fully subscribed in federated conversations</a></li>
+<li class="issue " data-updated="2026-04-30T12:44:03.000Z" data-index="7"><a href="https://github.com/nextcloud/spreed/issues/11768" target="_blank" rel="noreferrer">System message shows "guest added user" to a conversation when adding through circle/team</a></li>
+<li class="issue " data-updated="2026-04-30T12:44:02.000Z" data-index="8"><a href="https://github.com/nextcloud/spreed/issues/11746" target="_blank" rel="noreferrer">Write tests for "Team resources" integration</a></li>
+<li class="issue " data-updated="2026-04-30T12:43:37.000Z" data-index="9"><a href="https://github.com/nextcloud/spreed/issues/13777" target="_blank" rel="noreferrer">Temporary message added before date separator</a></li>
+<li class="issue " data-updated="2026-04-30T12:42:59.000Z" data-index="10"><a href="https://github.com/nextcloud/spreed/issues/15276" target="_blank" rel="noreferrer">Instant meeting outside of dashboard?</a></li>
+</ul></section>
+<section class="repo" data-index="13" data-newest="1776920590000"><h2><a href="https://github.com/louislam/uptime-kuma" target="_blank" rel="noreferrer">louislam/uptime-kuma</a></h2><ul><li class="issue stale" data-updated="2026-04-23T05:03:10.000Z" data-index="0"><a href="https://github.com/louislam/uptime-kuma/issues/5977" target="_blank" rel="noreferrer">Navbar in mobile view has broken navbar position when on the list tab</a></li>
+<li class="issue stale" data-updated="2026-04-21T06:20:12.000Z" data-index="1"><a href="https://github.com/louislam/uptime-kuma/issues/4337" target="_blank" rel="noreferrer">[GDPR] Add cookies consent when Google Analytics is Enabled</a></li>
+<li class="issue stale" data-updated="2026-04-21T06:19:29.000Z" data-index="2"><a href="https://github.com/louislam/uptime-kuma/issues/4304" target="_blank" rel="noreferrer">GameDig Discord Server Monitoring</a></li>
+<li class="issue stale" data-updated="2026-04-09T05:18:38.000Z" data-index="3"><a href="https://github.com/louislam/uptime-kuma/issues/7242" target="_blank" rel="noreferrer">Pausing a group does not pause the individual monitors of that group</a></li>
+<li class="issue stale" data-updated="2026-04-08T06:17:57.000Z" data-index="4"><a href="https://github.com/louislam/uptime-kuma/issues/5670" target="_blank" rel="noreferrer">Password Reset via CLI does not work on Embedded MariaDB</a></li>
+</ul></section>
+<section class="repo" data-index="14" data-newest="1777026918000"><h2><a href="https://github.com/nodejs/undici" target="_blank" rel="noreferrer">nodejs/undici</a></h2><ul><li class="issue stale" data-updated="2026-04-24T10:35:18.000Z" data-index="0"><a href="https://github.com/nodejs/undici/issues/3276" target="_blank" rel="noreferrer">interceptors: move signal handling to interceptor</a></li>
+</ul></section>
+<section class="repo" data-index="15" data-newest="1778005799000"><h2><a href="https://github.com/PipedreamHQ/pipedream" target="_blank" rel="noreferrer">PipedreamHQ/pipedream</a></h2><ul><li class="issue " data-updated="2026-05-05T18:29:59.000Z" data-index="0"><a href="https://github.com/PipedreamHQ/pipedream/issues/20754" target="_blank" rel="noreferrer">[ACTION] Alaiko / Zenfulfilment</a></li>
+<li class="issue " data-updated="2026-05-05T17:13:58.000Z" data-index="1"><a href="https://github.com/PipedreamHQ/pipedream/issues/20777" target="_blank" rel="noreferrer">[ACTION] openai-analyze-image-content: support configurable model (gpt-4.1, gpt-5, etc.)</a></li>
+<li class="issue " data-updated="2026-05-05T15:38:36.000Z" data-index="2"><a href="https://github.com/PipedreamHQ/pipedream/issues/20790" target="_blank" rel="noreferrer">[ACTION] Create item in Zoho Inventory</a></li>
+<li class="issue " data-updated="2026-05-05T13:54:10.000Z" data-index="3"><a href="https://github.com/PipedreamHQ/pipedream/issues/20789" target="_blank" rel="noreferrer">[ACTION] HubSpot Meeting Scheduler APIs</a></li>
+<li class="issue " data-updated="2026-05-05T01:21:10.000Z" data-index="4"><a href="https://github.com/PipedreamHQ/pipedream/issues/20787" target="_blank" rel="noreferrer">[ACTION] Apollo.io Search APIs</a></li>
+<li class="issue " data-updated="2026-05-04T09:30:51.000Z" data-index="5"><a href="https://github.com/PipedreamHQ/pipedream/issues/20431" target="_blank" rel="noreferrer">[ACTION] Remove Specific Label Function in Pipedrive</a></li>
+<li class="issue " data-updated="2026-05-04T07:47:10.000Z" data-index="6"><a href="https://github.com/PipedreamHQ/pipedream/issues/20778" target="_blank" rel="noreferrer">[ACTION] Zoho Desk - List Ticket Fields, List Departments</a></li>
+<li class="issue " data-updated="2026-05-01T22:43:21.000Z" data-index="7"><a href="https://github.com/PipedreamHQ/pipedream/issues/20773" target="_blank" rel="noreferrer">[ACTION]</a></li>
+<li class="issue " data-updated="2026-05-01T21:55:05.000Z" data-index="8"><a href="https://github.com/PipedreamHQ/pipedream/issues/20703" target="_blank" rel="noreferrer">[ACTION] Huntress new actions</a></li>
+<li class="issue " data-updated="2026-05-01T21:54:27.000Z" data-index="9"><a href="https://github.com/PipedreamHQ/pipedream/issues/20743" target="_blank" rel="noreferrer">[ACTION] [App] Ringba — request for additional pre-built components</a></li>
+<li class="issue " data-updated="2026-05-01T21:53:57.000Z" data-index="10"><a href="https://github.com/PipedreamHQ/pipedream/issues/20750" target="_blank" rel="noreferrer">[ACTIONS] Trolley - Add core actions for recipient and payout workflows</a></li>
+<li class="issue " data-updated="2026-05-01T21:53:34.000Z" data-index="11"><a href="https://github.com/PipedreamHQ/pipedream/issues/20719" target="_blank" rel="noreferrer">[ACTION] Databricks - Feature parity with the api key version</a></li>
+<li class="issue " data-updated="2026-05-01T17:22:05.000Z" data-index="12"><a href="https://github.com/PipedreamHQ/pipedream/issues/20762" target="_blank" rel="noreferrer">[ACTION] MEWS get bills and fetch rates</a></li>
+<li class="issue " data-updated="2026-05-01T13:15:56.000Z" data-index="13"><a href="https://github.com/PipedreamHQ/pipedream/issues/20688" target="_blank" rel="noreferrer">[ACTION] Statuspage - Fetch Active Incidents, Fetch Components, and Create/update maintenances</a></li>
+<li class="issue stale" data-updated="2026-04-23T19:24:40.000Z" data-index="14"><a href="https://github.com/PipedreamHQ/pipedream/issues/20623" target="_blank" rel="noreferrer">Tools for nexudus mcp</a></li>
+<li class="issue stale" data-updated="2026-04-23T19:23:24.000Z" data-index="15"><a href="https://github.com/PipedreamHQ/pipedream/issues/20659" target="_blank" rel="noreferrer">[ACTION]</a></li>
+<li class="issue stale" data-updated="2026-04-23T15:53:31.000Z" data-index="16"><a href="https://github.com/PipedreamHQ/pipedream/issues/20684" target="_blank" rel="noreferrer">[ACTION] Shopify - get tracking</a></li>
+<li class="issue stale" data-updated="2026-04-21T20:20:25.000Z" data-index="17"><a href="https://github.com/PipedreamHQ/pipedream/issues/20357" target="_blank" rel="noreferrer">[ACTION] teamleader update ticket</a></li>
+<li class="issue stale" data-updated="2026-04-21T18:33:04.000Z" data-index="18"><a href="https://github.com/PipedreamHQ/pipedream/issues/20554" target="_blank" rel="noreferrer">[ACTION] New Moodle actions</a></li>
+<li class="issue stale" data-updated="2026-04-17T16:26:34.000Z" data-index="19"><a href="https://github.com/PipedreamHQ/pipedream/issues/20510" target="_blank" rel="noreferrer">[components] Hedy</a></li>
+<li class="issue stale" data-updated="2026-04-17T16:25:10.000Z" data-index="20"><a href="https://github.com/PipedreamHQ/pipedream/issues/20536" target="_blank" rel="noreferrer">[ACTION] Microsoft teams upload image affordance</a></li>
+<li class="issue stale" data-updated="2026-04-17T16:24:25.000Z" data-index="21"><a href="https://github.com/PipedreamHQ/pipedream/issues/20534" target="_blank" rel="noreferrer">[ACTION] Hiver new actions</a></li>
+<li class="issue stale" data-updated="2026-04-17T16:06:40.000Z" data-index="22"><a href="https://github.com/PipedreamHQ/pipedream/issues/20537" target="_blank" rel="noreferrer">[ACTION] Simplify Notion upload image affordance</a></li>
+<li class="issue stale" data-updated="2026-04-17T16:06:09.000Z" data-index="23"><a href="https://github.com/PipedreamHQ/pipedream/issues/20599" target="_blank" rel="noreferrer">[ACTION] New Lever Actions</a></li>
+<li class="issue stale" data-updated="2026-04-17T05:15:15.000Z" data-index="24"><a href="https://github.com/PipedreamHQ/pipedream/issues/14309" target="_blank" rel="noreferrer">[TRIGGER] Discord new messages in thread</a></li>
+<li class="issue stale" data-updated="2026-04-17T05:14:26.000Z" data-index="25"><a href="https://github.com/PipedreamHQ/pipedream/issues/15367" target="_blank" rel="noreferrer">[shopify files upload] [Shopify Files section under Content Menu]</a></li>
+<li class="issue stale" data-updated="2026-04-17T05:13:45.000Z" data-index="26"><a href="https://github.com/PipedreamHQ/pipedream/issues/15378" target="_blank" rel="noreferrer">[FEATURE] Update Runware integration</a></li>
+<li class="issue stale" data-updated="2026-04-17T05:13:04.000Z" data-index="27"><a href="https://github.com/PipedreamHQ/pipedream/issues/16656" target="_blank" rel="noreferrer">[TRIGGER] watch a row</a></li>
+<li class="issue stale" data-updated="2026-04-17T05:12:14.000Z" data-index="28"><a href="https://github.com/PipedreamHQ/pipedream/issues/16725" target="_blank" rel="noreferrer">New Apollo recording available</a></li>
+<li class="issue stale" data-updated="2026-04-17T04:50:43.000Z" data-index="29"><a href="https://github.com/PipedreamHQ/pipedream/issues/15515" target="_blank" rel="noreferrer">[ACTIONS] Procore - Direct Costs API</a></li>
+<li class="issue stale" data-updated="2026-04-17T04:50:08.000Z" data-index="30"><a href="https://github.com/PipedreamHQ/pipedream/issues/16697" target="_blank" rel="noreferrer">[ACTION] notion - update page</a></li>
+<li class="issue stale" data-updated="2026-04-17T04:48:57.000Z" data-index="31"><a href="https://github.com/PipedreamHQ/pipedream/issues/18821" target="_blank" rel="noreferrer">[ACTION] Add CoinAPI MCP Server integration</a></li>
+<li class="issue stale" data-updated="2026-04-10T18:53:43.000Z" data-index="32"><a href="https://github.com/PipedreamHQ/pipedream/issues/20027" target="_blank" rel="noreferrer">[ACTION] Get DPD parcel status</a></li>
+</ul></section>
+<section class="repo" data-index="16" data-newest="1775755269000"><h2><a href="https://github.com/XRPLF/xrpl-dev-portal" target="_blank" rel="noreferrer">XRPLF/xrpl-dev-portal</a></h2><ul><li class="issue stale" data-updated="2026-04-09T17:21:09.000Z" data-index="0"><a href="https://github.com/XRPLF/xrpl-dev-portal/issues/3197" target="_blank" rel="noreferrer">Update channel_authorize to reflect that it's restricted like other signing methods</a></li>
+</ul></section>
+<section class="repo" data-index="17" data-newest="1777317458000"><h2><a href="https://github.com/CesiumGS/cesium" target="_blank" rel="noreferrer">CesiumGS/cesium</a></h2><ul><li class="issue stale" data-updated="2026-04-27T19:17:38.000Z" data-index="0"><a href="https://github.com/CesiumGS/cesium/issues/12826" target="_blank" rel="noreferrer">DeveloperError: Must define either _workerName or _workerPath for asynchronous geometry.</a></li>
+<li class="issue stale" data-updated="2026-04-08T10:43:03.000Z" data-index="1"><a href="https://github.com/CesiumGS/cesium/issues/11749" target="_blank" rel="noreferrer">Ongoing documentation fixes</a></li>
+</ul></section>
+<section class="repo" data-index="18" data-newest="1778030121000"><h2><a href="https://github.com/stdlib-js/stdlib" target="_blank" rel="noreferrer">stdlib-js/stdlib</a></h2><ul><li class="issue " data-updated="2026-05-06T01:15:21.000Z" data-index="0"><a href="https://github.com/stdlib-js/stdlib/issues/11958" target="_blank" rel="noreferrer">Fix JavaScript lint errors</a></li>
+<li class="issue " data-updated="2026-05-05T00:29:22.000Z" data-index="1"><a href="https://github.com/stdlib-js/stdlib/issues/11936" target="_blank" rel="noreferrer">Fix JavaScript lint errors</a></li>
+<li class="issue " data-updated="2026-05-04T15:57:14.000Z" data-index="2"><a href="https://github.com/stdlib-js/stdlib/issues/11896" target="_blank" rel="noreferrer">Fix TypeScript declarations lint errors</a></li>
+<li class="issue " data-updated="2026-05-01T00:45:18.000Z" data-index="3"><a href="https://github.com/stdlib-js/stdlib/issues/11868" target="_blank" rel="noreferrer">Fix broken Markdown link: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about</a></li>
+<li class="issue " data-updated="2026-05-01T00:31:39.000Z" data-index="4"><a href="https://github.com/stdlib-js/stdlib/issues/11867" target="_blank" rel="noreferrer">Fix JavaScript lint errors</a></li>
+<li class="issue stale" data-updated="2026-04-26T07:46:20.000Z" data-index="5"><a href="https://github.com/stdlib-js/stdlib/issues/11784" target="_blank" rel="noreferrer">Fix JavaScript lint errors</a></li>
+<li class="issue stale" data-updated="2026-04-14T17:55:19.000Z" data-index="6"><a href="https://github.com/stdlib-js/stdlib/issues/11352" target="_blank" rel="noreferrer">[RFC]: Migrate `math/base/special` packages from relative tolerance testing to ULP difference testing (tracking issue)</a></li>
+</ul></section>
+<section class="repo" data-index="19" data-newest="1778034306000"><h2><a href="https://github.com/hackforla/tdm-calculator" target="_blank" rel="noreferrer">hackforla/tdm-calculator</a></h2><ul><li class="issue " data-updated="2026-05-06T02:25:06.000Z" data-index="0"><a href="https://github.com/hackforla/tdm-calculator/issues/3018" target="_blank" rel="noreferrer">FAQ database: Add content: What happens to my submitted, but not-yet-approved, TDM Plan if the TDM Program Guidelines change?</a></li>
+<li class="issue " data-updated="2026-05-06T02:20:23.000Z" data-index="1"><a href="https://github.com/hackforla/tdm-calculator/issues/2754" target="_blank" rel="noreferrer">FAQ database: How to Submit a Snapshot</a></li>
+<li class="issue " data-updated="2026-05-06T02:17:55.000Z" data-index="2"><a href="https://github.com/hackforla/tdm-calculator/issues/3023" target="_blank" rel="noreferrer">FAQ database: Add content: How do I make revisions to my submitted TDM Plan that were requested by LADOT?</a></li>
+<li class="issue " data-updated="2026-05-06T01:43:47.000Z" data-index="3"><a href="https://github.com/hackforla/tdm-calculator/issues/3022" target="_blank" rel="noreferrer">FAQ database: Add content: I have an approved TDM Plan and my building has a Certificate of Occupancy. How do I modify my TDM Plan?</a></li>
+<li class="issue " data-updated="2026-05-06T00:07:00.000Z" data-index="4"><a href="https://github.com/hackforla/tdm-calculator/issues/3167" target="_blank" rel="noreferrer">Dev: Update the spelling linter exclusion list with new terms</a></li>
+<li class="issue stale" data-updated="2026-04-28T09:01:16.000Z" data-index="5"><a href="https://github.com/hackforla/tdm-calculator/issues/3029" target="_blank" rel="noreferrer">DEV: External links should open consistently across all pages.</a></li>
+<li class="issue stale" data-updated="2026-04-23T20:11:50.000Z" data-index="6"><a href="https://github.com/hackforla/tdm-calculator/issues/3109" target="_blank" rel="noreferrer">Bug: field focus on Page 1 is incorrect</a></li>
+<li class="issue stale" data-updated="2026-04-23T17:47:06.000Z" data-index="7"><a href="https://github.com/hackforla/tdm-calculator/issues/3024" target="_blank" rel="noreferrer">FAQ database: Add content: How do I revise my proposed TDM Plan while keeping the same version of the Program Guidelines as my original submission?</a></li>
+<li class="issue stale" data-updated="2026-04-18T19:48:00.000Z" data-index="8"><a href="https://github.com/hackforla/tdm-calculator/issues/3078" target="_blank" rel="noreferrer">Dev: Update text when there are no results on Submissions page</a></li>
+<li class="issue stale" data-updated="2026-04-15T19:42:32.000Z" data-index="9"><a href="https://github.com/hackforla/tdm-calculator/issues/2744" target="_blank" rel="noreferrer">FAQ database: Add content: How can I search and filter my projects</a></li>
+<li class="issue stale" data-updated="2026-04-09T20:40:24.000Z" data-index="10"><a href="https://github.com/hackforla/tdm-calculator/issues/2580" target="_blank" rel="noreferrer">Dev: Fix column heading alignment and Date format on Security page</a></li>
+</ul></section>
+<section class="repo" data-index="20" data-newest="1777467606000"><h2><a href="https://github.com/UltiMafia/Ultimafia" target="_blank" rel="noreferrer">UltiMafia/Ultimafia</a></h2><ul><li class="issue " data-updated="2026-04-29T13:00:06.000Z" data-index="0"><a href="https://github.com/UltiMafia/Ultimafia/issues/2774" target="_blank" rel="noreferrer">feat(game): role marker should allow exact-searches</a></li>
+</ul></section>
+<section class="repo" data-index="21" data-newest="1776172178000"><h2><a href="https://github.com/younisdev/dyvix-ui" target="_blank" rel="noreferrer">younisdev/dyvix-ui</a></h2><ul><li class="issue stale" data-updated="2026-04-14T13:09:38.000Z" data-index="0"><a href="https://github.com/younisdev/dyvix-ui/issues/100" target="_blank" rel="noreferrer">[Feature] Add `Warning` and `info` toast types.</a></li>
+<li class="issue stale" data-updated="2026-04-12T23:41:42.000Z" data-index="1"><a href="https://github.com/younisdev/dyvix-ui/issues/96" target="_blank" rel="noreferrer">[Chore] Move toast position styles into there own positions.css</a></li>
+</ul></section>
+<section class="repo" data-index="22" data-newest="1777808307000"><h2><a href="https://github.com/q5js/q5.js" target="_blank" rel="noreferrer">q5js/q5.js</a></h2><ul><li class="issue " data-updated="2026-05-03T11:38:27.000Z" data-index="0"><a href="https://github.com/q5js/q5.js/issues/123" target="_blank" rel="noreferrer">Create more MSDF fonts to put in q5's fonts folder</a></li>
+</ul></section>
+<section class="repo" data-index="23" data-newest="1776232541000"><h2><a href="https://github.com/carnworkstudios/TAFNE" target="_blank" rel="noreferrer">carnworkstudios/TAFNE</a></h2><ul><li class="issue stale" data-updated="2026-04-15T05:55:41.000Z" data-index="0"><a href="https://github.com/carnworkstudios/TAFNE/issues/7" target="_blank" rel="noreferrer">Table style presets (theme picker)</a></li>
+<li class="issue stale" data-updated="2026-04-13T04:24:20.000Z" data-index="1"><a href="https://github.com/carnworkstudios/TAFNE/issues/4" target="_blank" rel="noreferrer">Handle Global Undo/Redo across Mode Switches</a></li>
+<li class="issue stale" data-updated="2026-04-13T04:21:38.000Z" data-index="2"><a href="https://github.com/carnworkstudios/TAFNE/issues/3" target="_blank" rel="noreferrer">Export Node Graph as SVG/PNG</a></li>
+</ul></section>
+<section class="repo" data-index="24" data-newest="1777974799000"><h2><a href="https://github.com/OREL-group/Project-Management" target="_blank" rel="noreferrer">OREL-group/Project-Management</a></h2><ul><li class="issue " data-updated="2026-05-05T09:53:19.000Z" data-index="0"><a href="https://github.com/OREL-group/Project-Management/issues/216" target="_blank" rel="noreferrer">Add onboarding welcome screen for new users</a></li>
+<li class="issue stale" data-updated="2026-04-17T01:53:37.000Z" data-index="1"><a href="https://github.com/OREL-group/Project-Management/issues/123" target="_blank" rel="noreferrer">make a Start Here guide for plugin setup</a></li>
+<li class="issue stale" data-updated="2026-04-16T16:16:20.000Z" data-index="2"><a href="https://github.com/OREL-group/Project-Management/issues/95" target="_blank" rel="noreferrer">reaching out to investors</a></li>
+<li class="issue stale" data-updated="2026-04-16T15:54:02.000Z" data-index="3"><a href="https://github.com/OREL-group/Project-Management/issues/90" target="_blank" rel="noreferrer">create a organized database for the prototype</a></li>
+<li class="issue stale" data-updated="2026-04-14T20:02:35.000Z" data-index="4"><a href="https://github.com/OREL-group/Project-Management/issues/50" target="_blank" rel="noreferrer">Finalize Design Sprint Objectives</a></li>
+<li class="issue stale" data-updated="2026-04-07T05:50:07.000Z" data-index="5"><a href="https://github.com/OREL-group/Project-Management/issues/39" target="_blank" rel="noreferrer">Discover who we need to hire for the project</a></li>
+</ul></section>
+<section class="repo" data-index="25" data-newest="1778011135000"><h2><a href="https://github.com/LOLinDark/StreamerOps" target="_blank" rel="noreferrer">LOLinDark/StreamerOps</a></h2><ul><li class="issue " data-updated="2026-05-05T19:58:55.000Z" data-index="0"><a href="https://github.com/LOLinDark/StreamerOps/issues/12" target="_blank" rel="noreferrer">bug: hardcoded referral code placeholder in WelcomeOnline.jsx</a></li>
+<li class="issue " data-updated="2026-05-05T18:47:40.000Z" data-index="1"><a href="https://github.com/LOLinDark/StreamerOps/issues/14" target="_blank" rel="noreferrer">enhancement: add PropTypes validation to shared UI components</a></li>
+<li class="issue " data-updated="2026-05-05T18:47:31.000Z" data-index="2"><a href="https://github.com/LOLinDark/StreamerOps/issues/13" target="_blank" rel="noreferrer">chore: migrate wiki-seed docs from repo into the GitHub wiki</a></li>
+<li class="issue " data-updated="2026-05-05T18:47:05.000Z" data-index="3"><a href="https://github.com/LOLinDark/StreamerOps/issues/11" target="_blank" rel="noreferrer">docs: fill in Architecture section in documentation/README.md</a></li>
+<li class="issue " data-updated="2026-05-05T18:46:57.000Z" data-index="4"><a href="https://github.com/LOLinDark/StreamerOps/issues/10" target="_blank" rel="noreferrer">chore: add CONTRIBUTING.md with contributor guidelines</a></li>
+<li class="issue " data-updated="2026-05-05T18:46:49.000Z" data-index="5"><a href="https://github.com/LOLinDark/StreamerOps/issues/9" target="_blank" rel="noreferrer">chore: add a LICENSE file to the repository</a></li>
+<li class="issue " data-updated="2026-05-05T18:46:36.000Z" data-index="6"><a href="https://github.com/LOLinDark/StreamerOps/issues/8" target="_blank" rel="noreferrer">docs: replace OmniCore references with StreamerOps in documentation</a></li>
+</ul></section>
+<section class="repo" data-index="26" data-newest="1777829757000"><h2><a href="https://github.com/sugarlabs/musicblocks" target="_blank" rel="noreferrer">sugarlabs/musicblocks</a></h2><ul><li class="issue " data-updated="2026-05-03T17:35:57.000Z" data-index="0"><a href="https://github.com/sugarlabs/musicblocks/issues/2255" target="_blank" rel="noreferrer">Custom Pitch block's pie menu is reversed, no rotation, and no pitch preview</a></li>
+</ul></section>
+<section class="repo" data-index="27" data-newest="1777402230000"><h2><a href="https://github.com/OSC/ondemand" target="_blank" rel="noreferrer">OSC/ondemand</a></h2><ul><li class="issue stale" data-updated="2026-04-28T18:50:30.000Z" data-index="0"><a href="https://github.com/OSC/ondemand/issues/5293" target="_blank" rel="noreferrer">Don't compose strings with internationalizations</a></li>
+<li class="issue stale" data-updated="2026-04-20T14:18:16.000Z" data-index="1"><a href="https://github.com/OSC/ondemand/issues/866" target="_blank" rel="noreferrer">default MOTD</a></li>
+<li class="issue stale" data-updated="2026-04-10T23:16:21.000Z" data-index="2"><a href="https://github.com/OSC/ondemand/issues/132" target="_blank" rel="noreferrer">ActiveJobs: Show job submission time.</a></li>
+</ul></section>
+<section class="repo" data-index="28" data-newest="1776883652000"><h2><a href="https://github.com/dbt-labs/docs.getdbt.com" target="_blank" rel="noreferrer">dbt-labs/docs.getdbt.com</a></h2><ul><li class="issue stale" data-updated="2026-04-22T18:47:32.000Z" data-index="0"><a href="https://github.com/dbt-labs/docs.getdbt.com/issues/8908" target="_blank" rel="noreferrer">`--resource-type` is used by more than just `ls`</a></li>
+<li class="issue stale" data-updated="2026-04-16T22:05:35.000Z" data-index="1"><a href="https://github.com/dbt-labs/docs.getdbt.com/issues/8584" target="_blank" rel="noreferrer">fail fast docs only mentions `run` but works for `build` and `test` too</a></li>
+<li class="issue stale" data-updated="2026-04-16T22:02:08.000Z" data-index="2"><a href="https://github.com/dbt-labs/docs.getdbt.com/issues/5651" target="_blank" rel="noreferrer">[Core] Configurability of the timestamps in logs</a></li>
+</ul></section>
+<section class="repo" data-index="29" data-newest="1776831618000"><h2><a href="https://github.com/badges/shields" target="_blank" rel="noreferrer">badges/shields</a></h2><ul><li class="issue stale" data-updated="2026-04-22T04:20:18.000Z" data-index="0"><a href="https://github.com/badges/shields/issues/7581" target="_blank" rel="noreferrer">Badge request: SDKMAN</a></li>
+<li class="issue stale" data-updated="2026-04-06T14:45:17.000Z" data-index="1"><a href="https://github.com/badges/shields/issues/10162" target="_blank" rel="noreferrer">Azure DevOps - Build Badge - PAT Token not used on private projects</a></li>
+</ul></section>
+<section class="repo" data-index="30" data-newest="1777317522000"><h2><a href="https://github.com/wikispeedruns/wikipedia-speedruns" target="_blank" rel="noreferrer">wikispeedruns/wikipedia-speedruns</a></h2><ul><li class="issue stale" data-updated="2026-04-27T19:18:42.000Z" data-index="0"><a href="https://github.com/wikispeedruns/wikipedia-speedruns/issues/625" target="_blank" rel="noreferrer">Anchor tags on homepage doesn't highlight the tab for that part of the page.</a></li>
+</ul></section>
+<section class="repo" data-index="31" data-newest="1776104410000"><h2><a href="https://github.com/google/closure-compiler" target="_blank" rel="noreferrer">google/closure-compiler</a></h2><ul><li class="issue stale" data-updated="2026-04-13T18:20:10.000Z" data-index="0"><a href="https://github.com/google/closure-compiler/issues/4046" target="_blank" rel="noreferrer">Array constructor with length is not eliminated</a></li>
+</ul></section>
+<section class="repo" data-index="32" data-newest="1777781802000"><h2><a href="https://github.com/oss-slu/DigitalBoneBox" target="_blank" rel="noreferrer">oss-slu/DigitalBoneBox</a></h2><ul><li class="issue " data-updated="2026-05-03T04:16:42.000Z" data-index="0"><a href="https://github.com/oss-slu/DigitalBoneBox/issues/274" target="_blank" rel="noreferrer">Remove unused functions</a></li>
+<li class="issue stale" data-updated="2026-04-11T17:06:58.000Z" data-index="1"><a href="https://github.com/oss-slu/DigitalBoneBox/issues/233" target="_blank" rel="noreferrer">Label toggle</a></li>
+</ul></section>
+<section class="repo" data-index="33" data-newest="1777971641000"><h2><a href="https://github.com/sabbah13/cowork-tasks" target="_blank" rel="noreferrer">sabbah13/cowork-tasks</a></h2><ul><li class="issue " data-updated="2026-05-05T09:00:41.000Z" data-index="0"><a href="https://github.com/sabbah13/cowork-tasks/issues/30" target="_blank" rel="noreferrer">perf: lazy-load card detail panel</a></li>
+<li class="issue " data-updated="2026-05-04T06:55:17.000Z" data-index="1"><a href="https://github.com/sabbah13/cowork-tasks/issues/32" target="_blank" rel="noreferrer">a11y: keyboard navigation audit + fixes</a></li>
+<li class="issue " data-updated="2026-05-04T06:55:15.000Z" data-index="2"><a href="https://github.com/sabbah13/cowork-tasks/issues/31" target="_blank" rel="noreferrer">i18n: scaffolding for German and Japanese</a></li>
+<li class="issue " data-updated="2026-05-04T06:54:43.000Z" data-index="3"><a href="https://github.com/sabbah13/cowork-tasks/issues/29" target="_blank" rel="noreferrer">feat: snooze-until-tomorrow card action</a></li>
+<li class="issue " data-updated="2026-05-04T06:54:41.000Z" data-index="4"><a href="https://github.com/sabbah13/cowork-tasks/issues/28" target="_blank" rel="noreferrer">docs: 'first 5 minutes' walkthrough with screenshots</a></li>
+</ul></section>
+
+  </div>
+  <script>
+    let hideOld = false;
+    let sortRecent = false;
+    const container = document.getElementById('issues-container');
+
+    document.getElementById('btn-hide-old').addEventListener('click', function () {
+      hideOld = !hideOld;
+      this.classList.toggle('active', hideOld);
+      document.querySelectorAll('.issue.stale').forEach(el => el.classList.toggle('hidden', hideOld));
+      document.querySelectorAll('.repo').forEach(section => {
+        const hasVisible = section.querySelectorAll('.issue:not(.hidden)').length > 0;
+        section.classList.toggle('hidden', hideOld && !hasVisible);
+      });
+    });
+
+    document.getElementById('btn-sort-recent').addEventListener('click', function () {
+      sortRecent = !sortRecent;
+      this.classList.toggle('active', sortRecent);
+      const sections = Array.from(container.querySelectorAll('section.repo'));
+      if (sortRecent) {
+        sections.sort((a, b) => Number(b.dataset.newest) - Number(a.dataset.newest));
+      } else {
+        sections.sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+      }
+      sections.forEach(s => {
+        container.appendChild(s);
+        const items = Array.from(s.querySelectorAll('li'));
+        if (sortRecent) {
+          items.sort((a, b) => new Date(b.dataset.updated) - new Date(a.dataset.updated));
+        } else {
+          items.sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+        }
+        const ul = s.querySelector('ul');
+        ul.innerHTML = '';
+        ul.append(...items);
+      });
+    });
+  </script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const axios = require('axios');
 const fs = require('fs');
 const env = require('dotenv');
-const Markdown = require('markdown-to-html').Markdown;
 
 env.config();
 
@@ -183,37 +182,109 @@ const getGoodFirstIssues = async () => {
     }
 
     fs.writeFileSync('README.md', markdown);
+    return goodFirstIssues;
   } catch (error) {
     console.error(`An error occurred: ${error.message}`);
     process.exit();
   }
 };
 
-const convertToHtml = async () => {
-  try {
-    const md = new Markdown();
+const convertToHtml = (goodFirstIssues) => {
+  const STALE_DAYS = 7;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - STALE_DAYS);
 
-    md.render('README.md', {
-      title: 'Good Javascript First Issues',
-      highlight: true,
-      highlightTheme: 'github',
-      stylesheet: 'styles.css',
-      context: 'https://github.com',
-    }, function (err) {
-      if (err) {
-        throw err;
-      }
-      md.pipe(fs.createWriteStream('index.html'));
-    });
-  } catch (e) {
-    console.error('>>>' + e);
-    process.exit();
+  let repoSections = '';
+  for (let s = 0; s < goodFirstIssues.length; s++) {
+    const entry = goodFirstIssues[s];
+    const repoUrl = entry.issues[0].html_url.split('/issues')[0];
+    // most recent issue date for this repo (used for section-level sorting)
+    const newestDate = entry.issues.reduce((max, issue) => {
+      const d = issue.updated_at ? new Date(issue.updated_at).getTime() : 0;
+      return d > max ? d : max;
+    }, 0);
+    let items = '';
+    for (let i = 0; i < entry.issues.length; i++) {
+      const issue = entry.issues[i];
+      const date = issue.updated_at ? new Date(issue.updated_at).toISOString() : '';
+      const stale = date && new Date(date) < cutoff ? 'stale' : '';
+      items += `<li class="issue ${stale}" data-updated="${date}" data-index="${i}"><a href="${issue.html_url}" target="_blank" rel="noreferrer">${issue.title}</a></li>\n`;
+    }
+    repoSections += `<section class="repo" data-index="${s}" data-newest="${newestDate}"><h2><a href="${repoUrl}" target="_blank" rel="noreferrer">${entry.repo}</a></h2><ul>${items}</ul></section>\n`;
   }
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Good First Issues</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .controls { display: flex; gap: 12px; padding: 16px 0; }
+    .controls button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ccc; cursor: pointer; font-size: 14px; background: #f5f5f5; }
+    .controls button.active { background: #0969da; color: #fff; border-color: #0969da; }
+    .issue.hidden { display: none; }
+    .repo.hidden { display: none; }
+  </style>
+</head>
+<body>
+  <h1>Good First Issues</h1>
+  <p>JavaScript repositories with good first issues. Updated daily.</p>
+  <div class="controls">
+    <button id="btn-hide-old">Hide issues inactive for ${STALE_DAYS}+ days</button>
+    <button id="btn-sort-recent">Sort by most recent</button>
+  </div>
+  <div id="issues-container">
+  ${repoSections}
+  </div>
+  <script>
+    let hideOld = false;
+    let sortRecent = false;
+    const container = document.getElementById('issues-container');
+
+    document.getElementById('btn-hide-old').addEventListener('click', function () {
+      hideOld = !hideOld;
+      this.classList.toggle('active', hideOld);
+      document.querySelectorAll('.issue.stale').forEach(el => el.classList.toggle('hidden', hideOld));
+      document.querySelectorAll('.repo').forEach(section => {
+        const hasVisible = section.querySelectorAll('.issue:not(.hidden)').length > 0;
+        section.classList.toggle('hidden', hideOld && !hasVisible);
+      });
+    });
+
+    document.getElementById('btn-sort-recent').addEventListener('click', function () {
+      sortRecent = !sortRecent;
+      this.classList.toggle('active', sortRecent);
+      const sections = Array.from(container.querySelectorAll('section.repo'));
+      if (sortRecent) {
+        sections.sort((a, b) => Number(b.dataset.newest) - Number(a.dataset.newest));
+      } else {
+        sections.sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+      }
+      sections.forEach(s => {
+        container.appendChild(s);
+        const items = Array.from(s.querySelectorAll('li'));
+        if (sortRecent) {
+          items.sort((a, b) => new Date(b.dataset.updated) - new Date(a.dataset.updated));
+        } else {
+          items.sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+        }
+        const ul = s.querySelector('ul');
+        ul.innerHTML = '';
+        ul.append(...items);
+      });
+    });
+  </script>
+</body>
+</html>`;
+
+  fs.writeFileSync('index.html', html);
 };
 
 const main = async () => {
-  await getGoodFirstIssues();
-  await convertToHtml();
+  const data = await getGoodFirstIssues();
+  convertToHtml(data);
 };
 
 main();

--- a/issues.json
+++ b/issues.json
@@ -1,246 +1,788 @@
 {
-  "generated_at": "2025-09-11T19:31:38.203Z",
+  "generated_at": "2026-05-06T03:14:26.334Z",
   "items": [
     {
-      "id": 3406641409,
-      "title": "Games page game bug",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/641",
-      "updated_at": "2025-09-11T19:23:16Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "high-priority",
-        "frontend"
-      ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
-    },
-    {
-      "id": 3400359753,
-      "title": "Skip Vite to generate `.js` files for assets (images)",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/596",
-      "updated_at": "2025-09-11T19:07:04Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "help wanted",
-        "hacktoberfest",
-        "frontend"
-      ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
-    },
-    {
-      "id": 3391623135,
-      "title": "Super-Linter CSS errors",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/571",
-      "updated_at": "2025-09-11T16:28:29Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "help wanted",
-        "tests",
-        "high-priority",
-        "frontend",
-        "GitHub Sponsors $5"
-      ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
-    },
-    {
-      "id": 3382054812,
-      "title": "Increase and standardize the font size on the \"rules\" and \"terms\" pages",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/551",
-      "updated_at": "2025-09-11T16:24:24Z",
-      "labels": [
-        "good first issue",
-        "high-priority",
-        "frontend"
-      ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
-    },
-    {
-      "id": 3403809988,
-      "title": "Remove all alert() in script.js and create a custom and nice user-friendly alert by css/js",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/631",
-      "updated_at": "2025-09-11T04:52:22Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "help wanted",
-        "hacktoberfest",
-        "javascript",
-        "frontend"
-      ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
-    },
-    {
-      "id": 3403718110,
-      "title": "Add info to install Python packages from the `requirements.txt` file in `CONTRIBUTING` guide and clean up the `pre-commit` instructions",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/628",
-      "updated_at": "2025-09-10T19:42:46Z",
+      "id": 4208030320,
+      "title": "Create 'Law of the Week' content series for X/Twitter",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/21",
+      "updated_at": "2026-04-05T16:26:28Z",
       "labels": [
         "documentation",
         "good first issue",
-        "high-priority"
+        "phase-4"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
     },
     {
-      "id": 3214333621,
-      "title": "Need some server rules for Discord",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/170",
-      "updated_at": "2025-09-10T12:18:24Z",
+      "id": 4208028868,
+      "title": "Write blog post: 'Why your AI agent keeps lying about being done'",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/11",
+      "updated_at": "2026-04-05T16:25:35Z",
       "labels": [
         "documentation",
         "good first issue",
-        "help wanted",
-        "high-priority"
+        "phase-2"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
     },
     {
-      "id": 3400042303,
-      "title": "We need to double check to make sure we fully ignore _site and _deploy dir from eslint, prettier, pre-commit, and other linters/checkers",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/594",
-      "updated_at": "2025-09-10T11:42:55Z",
+      "id": 4208028737,
+      "title": "Record a 2-min before/after demo video",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/10",
+      "updated_at": "2026-04-05T16:25:30Z",
+      "labels": [
+        "documentation",
+        "good first issue",
+        "phase-2"
+      ],
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
+    },
+    {
+      "id": 4208028619,
+      "title": "Add full Gemini CLI integration (hooks + installer)",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/9",
+      "updated_at": "2026-04-05T16:25:25Z",
       "labels": [
         "enhancement",
         "good first issue",
-        "help wanted",
-        "hacktoberfest"
+        "phase-1"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
     },
     {
-      "id": 3400193927,
-      "title": "Deeply check TailwindCSS output css file",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/595",
-      "updated_at": "2025-09-10T11:30:03Z",
+      "id": 4208028483,
+      "title": "Submit to awesome-agent-skills listing",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/8",
+      "updated_at": "2026-04-05T16:25:21Z",
+      "labels": [
+        "documentation",
+        "good first issue",
+        "phase-1"
+      ],
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
+    },
+    {
+      "id": 4208028319,
+      "title": "Fix version badge mismatch in README",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/7",
+      "updated_at": "2026-04-05T16:25:15Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "phase-1"
+      ],
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
+    },
+    {
+      "id": 4206351138,
+      "title": "Improve observe.sh hook with configurable triggers",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/5",
+      "updated_at": "2026-04-05T16:25:00Z",
       "labels": [
         "enhancement",
         "good first issue",
-        "help wanted",
-        "hacktoberfest",
-        "frontend"
+        "phase-3"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
     },
     {
-      "id": 3399006627,
-      "title": "We should inline the bandit skips for more coverage",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/585",
-      "updated_at": "2025-09-09T17:07:00Z",
+      "id": 4206350913,
+      "title": "Create CONTRIBUTING.md guide",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/3",
+      "updated_at": "2026-04-05T16:24:58Z",
+      "labels": [
+        "documentation",
+        "good first issue",
+        "phase-1"
+      ],
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
+    },
+    {
+      "id": 4206350812,
+      "title": "Add unit tests for install.mjs",
+      "html_url": "https://github.com/naimkatiman/continuous-improvement/issues/2",
+      "updated_at": "2026-04-05T16:24:56Z",
+      "labels": [
+        "help wanted",
+        "good first issue",
+        "phase-1"
+      ],
+      "repo": "naimkatiman/continuous-improvement",
+      "org": "naimkatiman",
+      "repo_name": "continuous-improvement",
+      "repo_stars": 3,
+      "repo_forks": 4,
+      "repo_pushed_at": "2026-05-06T03:11:56Z"
+    },
+    {
+      "id": 1920685609,
+      "title": "Update readme and docs regarding optional plugins",
+      "html_url": "https://github.com/cdxgen/cdxgen/issues/599",
+      "updated_at": "2026-04-13T13:30:38Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "cdxgen/cdxgen",
+      "org": "cdxgen",
+      "repo_name": "cdxgen",
+      "repo_stars": 956,
+      "repo_forks": 245,
+      "repo_pushed_at": "2026-05-06T03:02:24Z"
+    },
+    {
+      "id": 2438169385,
+      "title": "Patterns from the pattern directory do not show if placed in a template",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/64104",
+      "updated_at": "2026-05-04T07:03:53Z",
+      "labels": [
+        "[Type] Bug",
+        "Good First Issue",
+        "[Status] In Progress",
+        "[Feature] Patterns",
+        "[Feature] Pattern Directory"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 4088420073,
+      "title": "Original PRs may not be tagged properly when a manual cherry-pick is performed.",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/76579",
+      "updated_at": "2026-05-02T19:52:24Z",
+      "labels": [
+        "[Type] Enhancement",
+        "Good First Issue",
+        "[Status] In Progress",
+        "[Type] Build Tooling"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 3534132685,
+      "title": "Page jumps away when trying to edit an anchor link",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/72505",
+      "updated_at": "2026-04-28T13:04:22Z",
+      "labels": [
+        "[Type] Bug",
+        "Good First Issue",
+        "[Status] In Progress",
+        "[Feature] Link Editing"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 3505381662,
+      "title": "Custom font upload not working",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/72265",
+      "updated_at": "2026-04-15T09:17:38Z",
+      "labels": [
+        "[Type] Bug",
+        "Good First Issue",
+        "[Status] In Progress",
+        "[Feature] Font Library"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 1846196937,
+      "title": "Since 6.3, the display ratio of images is broken when the size of the Image Block is specified.",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/53555",
+      "updated_at": "2026-04-15T05:27:05Z",
+      "labels": [
+        "[Type] Bug",
+        "Good First Issue",
+        "[Status] In Progress",
+        "Backwards Compatibility",
+        "[Block] Image",
+        "[Feature] Block Validation/Deprecation"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 382645898,
+      "title": "Meta boxes: update core styles to match Gutenberg's",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/12101",
+      "updated_at": "2026-04-09T17:33:11Z",
+      "labels": [
+        "[Type] Enhancement",
+        "Good First Issue",
+        "Needs Dev",
+        "[Feature] Meta Boxes",
+        "CSS Styling"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 630725515,
+      "title": "Code Quality: Refactor all React class components to functional components using hooks",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/22890",
+      "updated_at": "2026-04-09T05:36:12Z",
+      "labels": [
+        "Good First Issue",
+        "[Status] In Progress",
+        "[Type] Code Quality",
+        "[Package] Components",
+        "[Type] Tracking Issue"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 3829427016,
+      "title": "Pasting direct image URL inserts Embed block instead of Image block",
+      "html_url": "https://github.com/WordPress/gutenberg/issues/74734",
+      "updated_at": "2026-04-09T05:18:27Z",
+      "labels": [
+        "[Type] Bug",
+        "Good First Issue",
+        "[Status] In Progress",
+        "[Feature] Paste",
+        "[Block] Embed"
+      ],
+      "repo": "WordPress/gutenberg",
+      "org": "WordPress",
+      "repo_name": "gutenberg",
+      "repo_stars": 11629,
+      "repo_forks": 4791,
+      "repo_pushed_at": "2026-05-06T02:56:45Z"
+    },
+    {
+      "id": 782635170,
+      "title": "Misleading \"next-head-count is missing\" error for invalid head tags",
+      "html_url": "https://github.com/vercel/next.js/issues/20924",
+      "updated_at": "2026-04-30T15:36:14Z",
       "labels": [
         "good first issue",
-        "tests",
-        "low-priority",
+        "Linting",
+        "Metadata"
+      ],
+      "repo": "vercel/next.js",
+      "org": "vercel",
+      "repo_name": "next.js",
+      "repo_stars": 139286,
+      "repo_forks": 31020,
+      "repo_pushed_at": "2026-05-06T02:54:53Z"
+    },
+    {
+      "id": 1313063414,
+      "title": "POST request succeeds for pages with next dev",
+      "html_url": "https://github.com/vercel/next.js/issues/38863",
+      "updated_at": "2026-04-30T15:35:55Z",
+      "labels": [
+        "good first issue",
+        "bug",
+        "linear: next"
+      ],
+      "repo": "vercel/next.js",
+      "org": "vercel",
+      "repo_name": "next.js",
+      "repo_stars": 139286,
+      "repo_forks": 31020,
+      "repo_pushed_at": "2026-05-06T02:54:53Z"
+    },
+    {
+      "id": 1401970528,
+      "title": "Inconsistent Error Messaging / Handling in getStaticPaths",
+      "html_url": "https://github.com/vercel/next.js/issues/41281",
+      "updated_at": "2026-04-30T15:35:39Z",
+      "labels": [
+        "good first issue"
+      ],
+      "repo": "vercel/next.js",
+      "org": "vercel",
+      "repo_name": "next.js",
+      "repo_stars": 139286,
+      "repo_forks": 31020,
+      "repo_pushed_at": "2026-05-06T02:54:53Z"
+    },
+    {
+      "id": 1446714814,
+      "title": "Parameter on `AppType` is used incorrectly",
+      "html_url": "https://github.com/vercel/next.js/issues/42846",
+      "updated_at": "2026-04-30T15:35:21Z",
+      "labels": [
+        "good first issue",
+        "TypeScript"
+      ],
+      "repo": "vercel/next.js",
+      "org": "vercel",
+      "repo_name": "next.js",
+      "repo_stars": 139286,
+      "repo_forks": 31020,
+      "repo_pushed_at": "2026-05-06T02:54:53Z"
+    },
+    {
+      "id": 1832711514,
+      "title": "`@next/next/no-html-link-for-pages` rule does not work with `pageExtensions`",
+      "html_url": "https://github.com/vercel/next.js/issues/53473",
+      "updated_at": "2026-04-30T15:35:19Z",
+      "labels": [
+        "good first issue",
+        "Linting"
+      ],
+      "repo": "vercel/next.js",
+      "org": "vercel",
+      "repo_name": "next.js",
+      "repo_stars": 139286,
+      "repo_forks": 31020,
+      "repo_pushed_at": "2026-05-06T02:54:53Z"
+    },
+    {
+      "id": 4293209577,
+      "title": "Runtime-deprecate calling digest() on HMAC more than once",
+      "html_url": "https://github.com/nodejs/node/issues/62838",
+      "updated_at": "2026-05-04T18:13:44Z",
+      "labels": [
+        "crypto",
+        "good first issue",
+        "security"
+      ],
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
+    },
+    {
+      "id": 3875372022,
+      "title": "test_runner: node:coverage ignore comments exclude DA but leave BRDA in lcov output",
+      "html_url": "https://github.com/nodejs/node/issues/61586",
+      "updated_at": "2026-05-02T20:50:14Z",
+      "labels": [
+        "good first issue",
+        "test_runner"
+      ],
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
+    },
+    {
+      "id": 4327934297,
+      "title": "webstreams: narrow `ReadableStreamBYOBRequest.view` to `Uint8Array`",
+      "html_url": "https://github.com/nodejs/node/issues/62952",
+      "updated_at": "2026-05-02T14:38:30Z",
+      "labels": [
+        "good first issue",
+        "web streams",
+        "web-standards"
+      ],
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
+    },
+    {
+      "id": 4276019032,
+      "title": "crypto,quic: missing NULL checks for OpenSSL allocation functions",
+      "html_url": "https://github.com/nodejs/node/issues/62774",
+      "updated_at": "2026-04-28T18:30:52Z",
+      "labels": [
+        "crypto",
+        "good first issue"
+      ],
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
+    },
+    {
+      "id": 1479260436,
+      "title": "Cpplint produces false positives for FastApiOptions",
+      "html_url": "https://github.com/nodejs/node/issues/45761",
+      "updated_at": "2026-04-28T18:27:29Z",
+      "labels": [
+        "c++",
+        "good first issue",
         "python"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
     },
     {
-      "id": 3380216951,
-      "title": "Need small Google map embed for each meetup location on the meetup pages",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/545",
-      "updated_at": "2025-09-09T14:29:21Z",
+      "id": 3084881636,
+      "title": "Transpile TypeScript code inside `node_modules`.",
+      "html_url": "https://github.com/nodejs/node/issues/58429",
+      "updated_at": "2026-04-15T12:03:11Z",
       "labels": [
         "good first issue",
-        "high-priority"
+        "feature request",
+        "strip-types"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
     },
     {
-      "id": 3296751923,
-      "title": "We need to have all CSS responsive images",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/373",
-      "updated_at": "2025-09-05T21:03:20Z",
+      "id": 2199721792,
+      "title": "Recommend `node`/`default` conditions instead of `require`/`import` as a solution to the dual package hazard",
+      "html_url": "https://github.com/nodejs/node/issues/52174",
+      "updated_at": "2026-04-07T09:48:43Z",
+      "labels": [
+        "doc",
+        "good first issue"
+      ],
+      "repo": "nodejs/node",
+      "org": "nodejs",
+      "repo_name": "node",
+      "repo_stars": 117043,
+      "repo_forks": 35482,
+      "repo_pushed_at": "2026-05-06T02:53:39Z"
+    },
+    {
+      "id": 4162119736,
+      "title": "Incorrect logic for matching index.html",
+      "html_url": "https://github.com/HarperFast/harper/issues/297",
+      "updated_at": "2026-05-06T01:34:20Z",
+      "labels": [
+        "good first issue"
+      ],
+      "repo": "HarperFast/harper",
+      "org": "HarperFast",
+      "repo_name": "harper",
+      "repo_stars": 75,
+      "repo_forks": 5,
+      "repo_pushed_at": "2026-05-06T03:09:46Z"
+    },
+    {
+      "id": 4179738511,
+      "title": "Update TLS privateKey to use relative path and update tests",
+      "html_url": "https://github.com/HarperFast/harper/issues/307",
+      "updated_at": "2026-04-17T19:11:40Z",
+      "labels": [
+        "good first issue"
+      ],
+      "repo": "HarperFast/harper",
+      "org": "HarperFast",
+      "repo_name": "harper",
+      "repo_stars": 75,
+      "repo_forks": 5,
+      "repo_pushed_at": "2026-05-06T03:09:46Z"
+    },
+    {
+      "id": 3934645045,
+      "title": "Convert harper logger module to TypeScript",
+      "html_url": "https://github.com/HarperFast/harper/issues/145",
+      "updated_at": "2026-04-17T19:10:54Z",
+      "labels": [
+        "good first issue"
+      ],
+      "repo": "HarperFast/harper",
+      "org": "HarperFast",
+      "repo_name": "harper",
+      "repo_stars": 75,
+      "repo_forks": 5,
+      "repo_pushed_at": "2026-05-06T03:09:46Z"
+    },
+    {
+      "id": 4257461619,
+      "title": "descriptions of the views missing upon import",
+      "html_url": "https://github.com/nextcloud/tables/issues/2478",
+      "updated_at": "2026-04-13T19:47:47Z",
       "labels": [
         "bug",
         "good first issue",
-        "frontend"
+        "0. Needs triage"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "nextcloud/tables",
+      "org": "nextcloud",
+      "repo_name": "tables",
+      "repo_stars": 205,
+      "repo_forks": 41,
+      "repo_pushed_at": "2026-05-06T01:56:14Z"
     },
     {
-      "id": 3365919610,
-      "title": "Add \"Jasper\" to the Discord moderators section on the About page",
-      "html_url": "https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/issues/524",
-      "updated_at": "2025-08-29T08:13:09Z",
+      "id": 4276171975,
+      "title": "Replace `any` types with proper interfaces in small service files",
+      "html_url": "https://github.com/medic/cht-core/issues/10883",
+      "updated_at": "2026-05-04T07:12:59Z",
+      "labels": [
+        "Type: Technical issue",
+        "Good first issue"
+      ],
+      "repo": "medic/cht-core",
+      "org": "medic",
+      "repo_name": "cht-core",
+      "repo_stars": 537,
+      "repo_forks": 382,
+      "repo_pushed_at": "2026-05-06T01:37:54Z"
+    },
+    {
+      "id": 4276103339,
+      "title": "Migrate small Angular templates from structural directives to built-in control flow",
+      "html_url": "https://github.com/medic/cht-core/issues/10882",
+      "updated_at": "2026-04-26T11:04:18Z",
+      "labels": [
+        "Type: Technical issue",
+        "Good first issue"
+      ],
+      "repo": "medic/cht-core",
+      "org": "medic",
+      "repo_name": "cht-core",
+      "repo_stars": 537,
+      "repo_forks": 382,
+      "repo_pushed_at": "2026-05-06T01:37:54Z"
+    },
+    {
+      "id": 3786018429,
+      "title": "Add constants for 'task', 'target', and 'user-settings' document types",
+      "html_url": "https://github.com/medic/cht-core/issues/10548",
+      "updated_at": "2026-04-23T12:27:17Z",
+      "labels": [
+        "Type: Technical issue",
+        "Good first issue"
+      ],
+      "repo": "medic/cht-core",
+      "org": "medic",
+      "repo_name": "cht-core",
+      "repo_stars": 537,
+      "repo_forks": 382,
+      "repo_pushed_at": "2026-05-06T01:37:54Z"
+    },
+    {
+      "id": 3786017223,
+      "title": "Add constant for 'contact' document type",
+      "html_url": "https://github.com/medic/cht-core/issues/10545",
+      "updated_at": "2026-04-16T14:51:21Z",
+      "labels": [
+        "Type: Technical issue",
+        "Good first issue"
+      ],
+      "repo": "medic/cht-core",
+      "org": "medic",
+      "repo_name": "cht-core",
+      "repo_stars": 537,
+      "repo_forks": 382,
+      "repo_pushed_at": "2026-05-06T01:37:54Z"
+    },
+    {
+      "id": 3786016883,
+      "title": "Add constant for 'person' document type",
+      "html_url": "https://github.com/medic/cht-core/issues/10543",
+      "updated_at": "2026-04-16T14:50:07Z",
+      "labels": [
+        "Type: Technical issue",
+        "Good first issue"
+      ],
+      "repo": "medic/cht-core",
+      "org": "medic",
+      "repo_name": "cht-core",
+      "repo_stars": 537,
+      "repo_forks": 382,
+      "repo_pushed_at": "2026-05-06T01:37:54Z"
+    },
+    {
+      "id": 3449272913,
+      "title": "Investigate loading externally hosted media into forms",
+      "html_url": "https://github.com/medic/cht-core/issues/10323",
+      "updated_at": "2026-04-16T13:55:59Z",
+      "labels": [
+        "Good first issue"
+      ],
+      "repo": "medic/cht-core",
+      "org": "medic",
+      "repo_name": "cht-core",
+      "repo_stars": 537,
+      "repo_forks": 382,
+      "repo_pushed_at": "2026-05-06T01:37:54Z"
+    },
+    {
+      "id": 4373544849,
+      "title": "GSoC Program 2026: Add hyperlink to Meshery org",
+      "html_url": "https://github.com/meshery/meshery.io/issues/2661",
+      "updated_at": "2026-05-04T17:54:46Z",
+      "labels": [
+        "kind/enhancement",
+        "good first issue",
+        "help wanted",
+        "area/website"
+      ],
+      "repo": "meshery/meshery.io",
+      "org": "meshery",
+      "repo_name": "meshery.io",
+      "repo_stars": 755,
+      "repo_forks": 782,
+      "repo_pushed_at": "2026-05-06T01:21:27Z"
+    },
+    {
+      "id": 4272930811,
+      "title": "Revisión de la documentación",
+      "html_url": "https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/3",
+      "updated_at": "2026-04-16T02:50:22Z",
+      "labels": [
+        "documentation",
+        "enhancement",
+        "good first issue"
+      ],
+      "repo": "LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN",
+      "org": "LovelyStoOk",
+      "repo_name": "PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN",
+      "repo_stars": 0,
+      "repo_forks": 0,
+      "repo_pushed_at": "2026-05-06T01:03:37Z"
+    },
+    {
+      "id": 4272907463,
+      "title": "Sprints por hacer.",
+      "html_url": "https://github.com/LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN/issues/2",
+      "updated_at": "2026-04-16T02:43:28Z",
+      "labels": [
+        "documentation",
+        "enhancement",
+        "help wanted",
+        "good first issue"
+      ],
+      "repo": "LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN",
+      "org": "LovelyStoOk",
+      "repo_name": "PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN",
+      "repo_stars": 0,
+      "repo_forks": 0,
+      "repo_pushed_at": "2026-05-06T01:03:37Z"
+    },
+    {
+      "id": 4374771353,
+      "title": "Add support for `defaultValue` option for `puter.ui.setColorPicker` in puter app environment",
+      "html_url": "https://github.com/HeyPuter/puter/issues/2895",
+      "updated_at": "2026-05-05T01:47:41Z",
       "labels": [
         "good first issue",
-        "high-priority",
-        "frontend"
+        "help wanted"
       ],
-      "repo": "brisbanesocialchess/brisbanesocialchess.github.io",
-      "org": "brisbanesocialchess",
-      "repo_name": "brisbanesocialchess.github.io",
-      "repo_stars": 16,
-      "repo_forks": 44,
-      "repo_pushed_at": "2025-09-11T19:29:16Z"
+      "repo": "HeyPuter/puter",
+      "org": "HeyPuter",
+      "repo_name": "puter",
+      "repo_stars": 40925,
+      "repo_forks": 3719,
+      "repo_pushed_at": "2026-05-06T00:43:30Z"
     },
     {
-      "id": 3402047798,
-      "title": "Add Missing Emeritus Meshmate",
-      "html_url": "https://github.com/layer5io/layer5/issues/6815",
-      "updated_at": "2025-09-10T14:45:03Z",
+      "id": 4374762995,
+      "title": "Add support for `defaultValue` option for `puter.ui.prompt` in puter app environment",
+      "html_url": "https://github.com/HeyPuter/puter/issues/2894",
+      "updated_at": "2026-05-05T01:47:26Z",
+      "labels": [
+        "good first issue",
+        "help wanted"
+      ],
+      "repo": "HeyPuter/puter",
+      "org": "HeyPuter",
+      "repo_name": "puter",
+      "repo_stars": 40925,
+      "repo_forks": 3719,
+      "repo_pushed_at": "2026-05-06T00:43:30Z"
+    },
+    {
+      "id": 4386938895,
+      "title": "[Community] Member Profile: Lenox Wiltshire",
+      "html_url": "https://github.com/layer5io/layer5/issues/7700",
+      "updated_at": "2026-05-06T02:42:53Z",
+      "labels": [
+        "help wanted",
+        "good first issue",
+        "language/markdown",
+        "framework/gatsby",
+        "area/community"
+      ],
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
+    },
+    {
+      "id": 4328008137,
+      "title": "[Animation] Animate Meshery Architecture",
+      "html_url": "https://github.com/layer5io/layer5/issues/7661",
+      "updated_at": "2026-05-04T20:49:50Z",
       "labels": [
         "kind/bug",
         "help wanted",
@@ -250,123 +792,91 @@
       "repo": "layer5io/layer5",
       "org": "layer5io",
       "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 2096717835,
-      "title": "[Screenshots] AWS Elastic Kubernetes Service under 'How it Works See It in Action' section",
-      "html_url": "https://github.com/layer5io/layer5/issues/5322",
-      "updated_at": "2025-09-09T15:17:44Z",
+      "id": 4377470560,
+      "title": "Add Meshery Relationships Tutorial to Newcomers page",
+      "html_url": "https://github.com/layer5io/layer5/issues/7696",
+      "updated_at": "2026-05-04T16:19:10Z",
       "labels": [
-        "kind/enhancement",
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "layer5io/layer5",
-      "org": "layer5io",
-      "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
-    },
-    {
-      "id": 2992210714,
-      "title": "Update resources and hands-on labs with latest content",
-      "html_url": "https://github.com/layer5io/layer5/issues/6387",
-      "updated_at": "2025-09-09T12:46:12Z",
-      "labels": [
+        "kind/bug",
         "help wanted",
         "good first issue",
-        "kind/chore",
-        "issue/willfix"
+        "framework/gatsby"
       ],
       "repo": "layer5io/layer5",
       "org": "layer5io",
       "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 2616362277,
-      "title": "Replace MeshMap icons to new Kanvas logo",
-      "html_url": "https://github.com/layer5io/layer5/issues/6032",
-      "updated_at": "2025-09-03T11:27:29Z",
-      "labels": [
-        "kind/enhancement",
-        "good first issue",
-        "hacktoberfest",
-        "issue/willfix"
-      ],
-      "repo": "layer5io/layer5",
-      "org": "layer5io",
-      "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
-    },
-    {
-      "id": 3056694369,
-      "title": "add kanvas pop up",
-      "html_url": "https://github.com/layer5io/layer5/issues/6444",
-      "updated_at": "2025-09-03T10:43:28Z",
+      "id": 2113148152,
+      "title": "Update the structure of pages based on the latest sitemap revision available in Figma",
+      "html_url": "https://github.com/layer5io/layer5/issues/5359",
+      "updated_at": "2026-05-03T18:19:23Z",
       "labels": [
         "help wanted",
         "good first issue",
-        "kind/chore"
+        "language/markdown"
       ],
       "repo": "layer5io/layer5",
       "org": "layer5io",
       "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 1795469019,
-      "title": "[UI] Community Handbook Faq page need to be enhanced",
-      "html_url": "https://github.com/layer5io/layer5/issues/4518",
-      "updated_at": "2025-08-31T09:54:01Z",
+      "id": 4229558246,
+      "title": "[Sistent] Add Table component to the Sistent components page",
+      "html_url": "https://github.com/layer5io/layer5/issues/7607",
+      "updated_at": "2026-05-02T07:28:21Z",
       "labels": [
         "kind/enhancement",
         "help wanted",
         "good first issue",
-        "framework/gatsby",
-        "issue/willfix",
-        "framework/graphql",
-        "area/handbook"
+        "language/markdown",
+        "framework/react",
+        "project/sistent"
       ],
       "repo": "layer5io/layer5",
       "org": "layer5io",
       "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 3026498199,
-      "title": "add max-width to images on learnign-paths",
-      "html_url": "https://github.com/layer5io/layer5/issues/6411",
-      "updated_at": "2025-08-28T08:14:28Z",
+      "id": 4363175110,
+      "title": "[Sistent] Add Data Table component to the Sistent components page",
+      "html_url": "https://github.com/layer5io/layer5/issues/7681",
+      "updated_at": "2026-05-01T22:48:52Z",
       "labels": [
+        "kind/enhancement",
         "help wanted",
         "good first issue",
-        "kind/chore"
+        "language/javascript",
+        "language/markdown",
+        "framework/react",
+        "project/sistent"
       ],
       "repo": "layer5io/layer5",
       "org": "layer5io",
       "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
       "id": 3066783036,
       "title": "[SEO] First Contentful Paint (FCP): gatsby-plugin-webpack-bundle-analyser-v2",
       "html_url": "https://github.com/layer5io/layer5/issues/6449",
-      "updated_at": "2025-08-28T08:09:57Z",
+      "updated_at": "2026-05-01T16:00:43Z",
       "labels": [
         "help wanted",
         "good first issue",
@@ -380,1740 +890,186 @@
       "repo": "layer5io/layer5",
       "org": "layer5io",
       "repo_name": "layer5",
-      "repo_stars": 948,
-      "repo_forks": 1376,
-      "repo_pushed_at": "2025-09-11T19:22:23Z"
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 3407770800,
-      "title": "Page for adding a new Experience",
-      "html_url": "https://github.com/MLH-Fellowship/orientation-project-js-25.FAL.A/issues/11",
-      "updated_at": "2025-09-11T19:17:51Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "MLH-Fellowship/orientation-project-js-25.FAL.A",
-      "org": "MLH-Fellowship",
-      "repo_name": "orientation-project-js-25.FAL.A",
-      "repo_stars": 0,
-      "repo_forks": 0,
-      "repo_pushed_at": "2025-09-11T19:16:08Z"
-    },
-    {
-      "id": 3407770412,
-      "title": "Page for adding a new Education",
-      "html_url": "https://github.com/MLH-Fellowship/orientation-project-js-25.FAL.A/issues/10",
-      "updated_at": "2025-09-11T19:17:41Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "MLH-Fellowship/orientation-project-js-25.FAL.A",
-      "org": "MLH-Fellowship",
-      "repo_name": "orientation-project-js-25.FAL.A",
-      "repo_stars": 0,
-      "repo_forks": 0,
-      "repo_pushed_at": "2025-09-11T19:16:08Z"
-    },
-    {
-      "id": 3407770024,
-      "title": "Page for adding a new Skill",
-      "html_url": "https://github.com/MLH-Fellowship/orientation-project-js-25.FAL.A/issues/9",
-      "updated_at": "2025-09-11T19:17:30Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "MLH-Fellowship/orientation-project-js-25.FAL.A",
-      "org": "MLH-Fellowship",
-      "repo_name": "orientation-project-js-25.FAL.A",
-      "repo_stars": 0,
-      "repo_forks": 0,
-      "repo_pushed_at": "2025-09-11T19:16:08Z"
-    },
-    {
-      "id": 3407766522,
-      "title": "Ability to add users information to the top of the resume",
-      "html_url": "https://github.com/MLH-Fellowship/orientation-project-js-25.FAL.A/issues/1",
-      "updated_at": "2025-09-11T19:16:07Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "MLH-Fellowship/orientation-project-js-25.FAL.A",
-      "org": "MLH-Fellowship",
-      "repo_name": "orientation-project-js-25.FAL.A",
-      "repo_stars": 0,
-      "repo_forks": 0,
-      "repo_pushed_at": "2025-09-11T19:16:08Z"
-    },
-    {
-      "id": 3400809502,
-      "title": "Complete the German (Deutsch) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1532",
-      "updated_at": "2025-09-10T16:34:01Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400809181,
-      "title": "Complete Emoji(🌍) translation based on English file",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1531",
-      "updated_at": "2025-09-10T04:54:55Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400809659,
-      "title": "Complete the Danish (Dansk) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1533",
-      "updated_at": "2025-09-10T03:48:56Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400808744,
-      "title": "Complete the Farsi (فارسی) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1529",
-      "updated_at": "2025-09-10T03:48:14Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400808493,
-      "title": "Complete the Finnish (Suomi) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1528",
-      "updated_at": "2025-09-10T03:48:06Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400808251,
-      "title": "Complete the French (Français) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1527",
-      "updated_at": "2025-09-10T03:47:57Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400808057,
-      "title": "Complete the Hebrew (עברית) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1526",
-      "updated_at": "2025-09-10T03:47:50Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400807682,
-      "title": "Complete the Hungarian (Magyar) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1524",
-      "updated_at": "2025-09-10T03:47:35Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400807474,
-      "title": "Complete Armenian (Հայերեն) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1523",
-      "updated_at": "2025-09-10T03:47:27Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400807238,
-      "title": "Complete the Indonesian (Bahasa Indonesia) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1522",
-      "updated_at": "2025-09-10T03:47:18Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400807013,
-      "title": "Complete the Igbo translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1521",
-      "updated_at": "2025-09-10T03:47:09Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400806799,
-      "title": "Complete the Italian (Italiano) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1520",
-      "updated_at": "2025-09-10T03:47:00Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400806617,
-      "title": "Complete the Japanese (日本語) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1519",
-      "updated_at": "2025-09-10T03:46:52Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400806450,
-      "title": "Complete the Korean (한국어) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1518",
-      "updated_at": "2025-09-10T03:46:45Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400806277,
-      "title": "Complete the Kurdish (کوردی) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1517",
-      "updated_at": "2025-09-10T03:46:37Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400806033,
-      "title": "Complete the Norwegian Bokmål (Norsk Bokmål) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1516",
-      "updated_at": "2025-09-10T03:46:28Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400805769,
-      "title": "Complete the Dutch (Nederlands) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1515",
-      "updated_at": "2025-09-10T03:46:19Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400805295,
-      "title": "Complete the Norwegian Nynorsk (Norsk Nynorsk) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1514",
-      "updated_at": "2025-09-10T03:46:05Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400804984,
-      "title": "Complete the Polish (Polski) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1513",
-      "updated_at": "2025-09-10T03:45:52Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400803838,
-      "title": "Complete the Portuguese (Português) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1512",
-      "updated_at": "2025-09-10T03:45:12Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400803166,
-      "title": "Complete the Romanian (Română) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1511",
-      "updated_at": "2025-09-10T03:44:46Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400798959,
-      "title": "Complete the Russian (Русский) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1510",
-      "updated_at": "2025-09-10T03:42:46Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400796748,
-      "title": "Complete the Swedish (Svenska) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1509",
-      "updated_at": "2025-09-10T03:41:43Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400796034,
-      "title": "Complete the Tamil (ஆங்கிலம்) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1508",
-      "updated_at": "2025-09-10T03:41:13Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400795403,
-      "title": "Complete the Thai (ไทย) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1507",
-      "updated_at": "2025-09-10T03:40:47Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400794574,
-      "title": "Complete the Turkish (Türkçe) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1506",
-      "updated_at": "2025-09-10T03:40:18Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400793581,
-      "title": "Complete the Ukrainian (Українська) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1505",
-      "updated_at": "2025-09-10T03:39:39Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400792845,
-      "title": "Complete the Urdu (اردو) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1504",
-      "updated_at": "2025-09-10T03:39:09Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400792260,
-      "title": "Complete the Vietnamese (Tiếng Việt) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1503",
-      "updated_at": "2025-09-10T03:38:44Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400791523,
-      "title": "Complete the Chinese (中文) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1502",
-      "updated_at": "2025-09-10T03:38:16Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400783325,
-      "title": "Complete the Traditional Chinese (繁體中文) translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1501",
-      "updated_at": "2025-09-10T03:34:37Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 3400776638,
-      "title": "Complete the Brazilian translation of Puter",
-      "html_url": "https://github.com/HeyPuter/puter/issues/1500",
-      "updated_at": "2025-09-10T03:32:05Z",
-      "labels": [
-        "good first issue",
-        "help wanted",
-        "translation"
-      ],
-      "repo": "HeyPuter/puter",
-      "org": "HeyPuter",
-      "repo_name": "puter",
-      "repo_stars": 36129,
-      "repo_forks": 2806,
-      "repo_pushed_at": "2025-09-11T19:12:42Z"
-    },
-    {
-      "id": 1832711514,
-      "title": "`@next/next/no-html-link-for-pages` rule does not work with `pageExtensions`",
-      "html_url": "https://github.com/vercel/next.js/issues/53473",
-      "updated_at": "2025-09-07T23:42:02Z",
-      "labels": [
-        "good first issue",
-        "Linting"
-      ],
-      "repo": "vercel/next.js",
-      "org": "vercel",
-      "repo_name": "next.js",
-      "repo_stars": 134344,
-      "repo_forks": 29291,
-      "repo_pushed_at": "2025-09-11T19:04:43Z"
-    },
-    {
-      "id": 1313063414,
-      "title": "POST request succeeds for pages with next dev",
-      "html_url": "https://github.com/vercel/next.js/issues/38863",
-      "updated_at": "2025-09-01T19:50:52Z",
-      "labels": [
-        "good first issue",
-        "bug",
-        "linear: next"
-      ],
-      "repo": "vercel/next.js",
-      "org": "vercel",
-      "repo_name": "next.js",
-      "repo_stars": 134344,
-      "repo_forks": 29291,
-      "repo_pushed_at": "2025-09-11T19:04:43Z"
-    },
-    {
-      "id": 3400673048,
-      "title": "Enable Default Master Design Hyperlink in meshery-design-embed",
-      "html_url": "https://github.com/layer5labs/meshery-extensions-packages/issues/526",
-      "updated_at": "2025-09-10T03:40:11Z",
+      "id": 2098071677,
+      "title": "[Screenshots] Old Screenshots of Meshery Playground needs to be updated",
+      "html_url": "https://github.com/layer5io/layer5/issues/5342",
+      "updated_at": "2026-04-30T19:21:35Z",
       "labels": [
         "kind/enhancement",
-        "good first issue",
         "help wanted",
-        "issue/design required"
-      ],
-      "repo": "layer5labs/meshery-extensions-packages",
-      "org": "layer5labs",
-      "repo_name": "meshery-extensions-packages",
-      "repo_stars": 49,
-      "repo_forks": 69,
-      "repo_pushed_at": "2025-09-11T18:54:40Z"
-    },
-    {
-      "id": 3391513960,
-      "title": "Links to Mapping files are not wroking",
-      "html_url": "https://github.com/NMRLipids/BilayerGUI_laravel/issues/19",
-      "updated_at": "2025-09-10T07:06:02Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "core dev task"
-      ],
-      "repo": "NMRLipids/BilayerGUI_laravel",
-      "org": "NMRLipids",
-      "repo_name": "BilayerGUI_laravel",
-      "repo_stars": 1,
-      "repo_forks": 3,
-      "repo_pushed_at": "2025-09-11T19:17:16Z"
-    },
-    {
-      "id": 3391502119,
-      "title": "Membrane count on frontpage shows -1 for empty database",
-      "html_url": "https://github.com/NMRLipids/BilayerGUI_laravel/issues/18",
-      "updated_at": "2025-09-07T10:59:33Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "core dev task"
-      ],
-      "repo": "NMRLipids/BilayerGUI_laravel",
-      "org": "NMRLipids",
-      "repo_name": "BilayerGUI_laravel",
-      "repo_stars": 1,
-      "repo_forks": 3,
-      "repo_pushed_at": "2025-09-11T19:17:16Z"
-    },
-    {
-      "id": 1465599359,
-      "title": "Give user alert to confirm browser refresh",
-      "html_url": "https://github.com/WordPress/wordpress-playground/issues/81",
-      "updated_at": "2025-08-27T08:09:13Z",
-      "labels": [
-        "[Type] Enhancement",
-        "Good First Issue",
-        "[Type] UI / UX / User Experience"
-      ],
-      "repo": "WordPress/wordpress-playground",
-      "org": "WordPress",
-      "repo_name": "wordpress-playground",
-      "repo_stars": 1792,
-      "repo_forks": 335,
-      "repo_pushed_at": "2025-09-11T18:44:53Z"
-    },
-    {
-      "id": 3373897620,
-      "title": "New SPARKLE for Tracks button",
-      "html_url": "https://github.com/Hylozoic/hylo/issues/868",
-      "updated_at": "2025-09-01T22:54:15Z",
-      "labels": [
-        "enhancement",
         "good first issue"
       ],
-      "repo": "Hylozoic/hylo",
-      "org": "Hylozoic",
-      "repo_name": "hylo",
-      "repo_stars": 13,
-      "repo_forks": 3,
-      "repo_pushed_at": "2025-09-11T18:39:14Z"
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 2570499826,
-      "title": "Inconsistent Conversation Bubble Sizes with YAML Code Blocks in Widescreen Mode",
-      "html_url": "https://github.com/open-webui/open-webui/issues/5975",
-      "updated_at": "2025-08-23T16:58:37Z",
-      "labels": [
-        "good first issue",
-        "help wanted"
-      ],
-      "repo": "open-webui/open-webui",
-      "org": "open-webui",
-      "repo_name": "open-webui",
-      "repo_stars": 109581,
-      "repo_forks": 14993,
-      "repo_pushed_at": "2025-09-11T18:29:03Z"
-    },
-    {
-      "id": 3378424896,
-      "title": "Add Scroll-to-Bottom Button to Improve Navigation\n",
-      "html_url": "https://github.com/eccentriccoder01/Venturalink/issues/27",
-      "updated_at": "2025-09-10T14:42:49Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "gssoc25",
-        "level 1"
-      ],
-      "repo": "eccentriccoder01/Venturalink",
-      "org": "eccentriccoder01",
-      "repo_name": "Venturalink",
-      "repo_stars": 7,
-      "repo_forks": 15,
-      "repo_pushed_at": "2025-09-11T18:26:36Z"
-    },
-    {
-      "id": 3309886833,
-      "title": "Remove or Adjust down scroll to explore text & line",
-      "html_url": "https://github.com/eccentriccoder01/Venturalink/issues/7",
-      "updated_at": "2025-08-12T12:49:30Z",
-      "labels": [
-        "good first issue",
-        "gssoc25",
-        "level 1"
-      ],
-      "repo": "eccentriccoder01/Venturalink",
-      "org": "eccentriccoder01",
-      "repo_name": "Venturalink",
-      "repo_stars": 7,
-      "repo_forks": 15,
-      "repo_pushed_at": "2025-09-11T18:26:36Z"
-    },
-    {
-      "id": 3287917521,
-      "title": "[TRIGGER] Coinbase / x402",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/17934",
-      "updated_at": "2025-09-11T18:22:57Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "trigger / source",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3389650972,
-      "title": "[ACTION] Hubspot Page - Widgets missing from the update page action",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18300",
-      "updated_at": "2025-09-11T18:21:38Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3398025543,
-      "title": "[ACTION] - Affinity CRM MCP",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18318",
-      "updated_at": "2025-09-11T17:21:56Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3395757519,
-      "title": "[TRIGGER] Migrate from Google Drive File Subscriptions API to Changes API to Avoid Rate Limits",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18315",
-      "updated_at": "2025-09-11T14:41:15Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "trigger / source",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3337836143,
-      "title": "[ACTION] Salesforce Marketing Cloud Engagement API",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18124",
-      "updated_at": "2025-09-11T01:20:27Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3389983586,
-      "title": "SEVDESK - TimeTracker2Excel or Sheets",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18301",
-      "updated_at": "2025-09-11T00:27:18Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "trigger / source",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3337883695,
-      "title": "[ACTION] Databricks API extension",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18126",
-      "updated_at": "2025-09-05T19:07:11Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3380481802,
-      "title": "Add FullStory API Integration to MCP Server - Session Data and Events Access",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18263",
-      "updated_at": "2025-09-05T07:52:34Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3377945541,
-      "title": "[ACTION] Braze MCP",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18257",
-      "updated_at": "2025-09-04T22:09:13Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3372916578,
-      "title": "[ACTION] Microsoft Booking",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18231",
-      "updated_at": "2025-09-02T14:05:29Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3349726434,
-      "title": "Everhour Events",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18163",
-      "updated_at": "2025-08-26T02:08:45Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "trigger / source",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3336658194,
-      "title": "[ACTION] Add https://zapr.link/ integration - it has also MCP",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18123",
-      "updated_at": "2025-08-21T19:34:53Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3290462497,
-      "title": "[ACTION] Slack \"list_replies\" tool MCP needs to be improved",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/17939",
-      "updated_at": "2025-08-21T07:07:28Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 1536080200,
-      "title": "Groupon API",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/5200",
-      "updated_at": "2025-08-19T00:56:18Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "app",
-        "triaged",
-        "added to app backlog",
-        "Outreach"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3312939608,
-      "title": "Netatmo",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18017",
-      "updated_at": "2025-08-18T05:57:42Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3113255550,
-      "title": "[ACTION] Picqer.com MCP server",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/16939",
-      "updated_at": "2025-08-15T16:53:42Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "action",
-        "app",
-        "triaged",
-        "Outreach"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3301445827,
-      "title": "[ACTION] Polar.sh",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/17977",
-      "updated_at": "2025-08-13T15:36:30Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "action"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3300045035,
-      "title": "[TRIGGER]",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/17972",
-      "updated_at": "2025-08-12T03:49:07Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "question",
-        "trigger / source"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3247673129,
-      "title": "[TRIGGERS] Facebook Pages",
-      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/17713",
-      "updated_at": "2025-08-12T02:36:23Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "action",
-        "triaged"
-      ],
-      "repo": "PipedreamHQ/pipedream",
-      "org": "PipedreamHQ",
-      "repo_name": "pipedream",
-      "repo_stars": 10556,
-      "repo_forks": 5490,
-      "repo_pushed_at": "2025-09-11T19:22:05Z"
-    },
-    {
-      "id": 3069397054,
-      "title": "feat: Add codex integration",
-      "html_url": "https://github.com/eyaltoledano/claude-task-master/issues/524",
-      "updated_at": "2025-09-01T15:14:22Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "eyaltoledano/claude-task-master",
-      "org": "eyaltoledano",
-      "repo_name": "claude-task-master",
-      "repo_stars": 21871,
-      "repo_forks": 2128,
-      "repo_pushed_at": "2025-09-11T18:11:47Z"
-    },
-    {
-      "id": 3164250466,
-      "title": "Automated README Progress Badges & Table",
-      "html_url": "https://github.com/eyaltoledano/claude-task-master/issues/838",
-      "updated_at": "2025-08-28T14:22:37Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "eyaltoledano/claude-task-master",
-      "org": "eyaltoledano",
-      "repo_name": "claude-task-master",
-      "repo_stars": 21871,
-      "repo_forks": 2128,
-      "repo_pushed_at": "2025-09-11T18:11:47Z"
-    },
-    {
-      "id": 3292783726,
-      "title": "[pt] Localize /community pages",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7475",
-      "updated_at": "2025-09-11T14:50:22Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "lang:pt"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3305136718,
-      "title": "[es] Spanish folder localization community",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7516",
-      "updated_at": "2025-09-09T15:51:06Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "docs",
-        "lang:es"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3307831913,
-      "title": "[es] Fix Spanish localization drifted pages",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7521",
-      "updated_at": "2025-09-06T20:41:24Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "docs",
-        "cleanup/refactoring",
-        "lang:es"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 2539942335,
-      "title": "[es] Spanish folder localization docs/languages",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/5229",
-      "updated_at": "2025-08-21T18:32:25Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "docs",
-        "lang:es"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3315442167,
-      "title": "[es] Spanish folder localization blogs",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7535",
-      "updated_at": "2025-08-21T18:12:19Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "docs",
-        "lang:es"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3318068238,
-      "title": "[pt] Localize content/en/docs/platforms pages",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7545",
-      "updated_at": "2025-08-13T22:05:28Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "lang:pt"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3318048099,
-      "title": "[pt] Localize content/en/docs/demo pages",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7544",
-      "updated_at": "2025-08-13T11:23:16Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "lang:pt"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3297534682,
-      "title": "[es] Spanish folder localization ecosystem",
-      "html_url": "https://github.com/open-telemetry/opentelemetry.io/issues/7488",
-      "updated_at": "2025-08-12T19:39:22Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "docs",
-        "lang:es"
-      ],
-      "repo": "open-telemetry/opentelemetry.io",
-      "org": "open-telemetry",
-      "repo_name": "opentelemetry.io",
-      "repo_stars": 762,
-      "repo_forks": 1516,
-      "repo_pushed_at": "2025-09-11T19:26:56Z"
-    },
-    {
-      "id": 3347163336,
-      "title": "Cannot call `unmount` method with using Attachment and $state",
-      "html_url": "https://github.com/sveltejs/svelte/issues/16656",
-      "updated_at": "2025-09-07T23:38:01Z",
-      "labels": [
-        "good first issue"
-      ],
-      "repo": "sveltejs/svelte",
-      "org": "sveltejs",
-      "repo_name": "svelte",
-      "repo_stars": 84066,
-      "repo_forks": 4613,
-      "repo_pushed_at": "2025-09-11T17:38:13Z"
-    },
-    {
-      "id": 2853739122,
-      "title": "Docs: Add a link from [svelte-transition](https://svelte.dev/docs/svelte-transition) to [svelte/transition](https://svelte.dev/docs/svelte/transition) page",
-      "html_url": "https://github.com/sveltejs/svelte/issues/15296",
-      "updated_at": "2025-08-17T18:50:08Z",
-      "labels": [
-        "good first issue",
-        "documentation"
-      ],
-      "repo": "sveltejs/svelte",
-      "org": "sveltejs",
-      "repo_name": "svelte",
-      "repo_stars": 84066,
-      "repo_forks": 4613,
-      "repo_pushed_at": "2025-09-11T17:38:13Z"
-    },
-    {
-      "id": 3407702732,
-      "title": "[UI] Enhance meshery operator connectivity check button behavior based on the real operator status value.",
-      "html_url": "https://github.com/meshery/meshery/issues/15814",
-      "updated_at": "2025-09-11T18:55:10Z",
+      "id": 3463441158,
+      "title": "[Performance] Improve Home Page Performance (layer5.io)",
+      "html_url": "https://github.com/layer5io/layer5/issues/6924",
+      "updated_at": "2026-04-30T09:33:04Z",
       "labels": [
         "kind/bug",
+        "help wanted",
+        "good first issue",
+        "hacktoberfest",
+        "framework/gatsby",
+        "type/performance"
+      ],
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
+    },
+    {
+      "id": 2992210714,
+      "title": "Update resources and hands-on labs with latest content",
+      "html_url": "https://github.com/layer5io/layer5/issues/6387",
+      "updated_at": "2026-04-29T15:15:57Z",
+      "labels": [
+        "help wanted",
+        "good first issue",
+        "kind/chore",
+        "issue/willfix"
+      ],
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
+    },
+    {
+      "id": 3021066899,
+      "title": "[CI] Create or add to existing workflow: a broken link checker",
+      "html_url": "https://github.com/layer5io/layer5/issues/6407",
+      "updated_at": "2026-04-29T13:59:37Z",
+      "labels": [
+        "help wanted",
+        "good first issue",
+        "kind/chore"
+      ],
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
+    },
+    {
+      "id": 4343650677,
+      "title": "[Sistent] Add ClickAwayListener component to the sistent components page",
+      "html_url": "https://github.com/layer5io/layer5/issues/7668",
+      "updated_at": "2026-04-29T10:50:32Z",
+      "labels": [
+        "kind/bug",
+        "help wanted",
+        "good first issue",
+        "framework/gatsby"
+      ],
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
+    },
+    {
+      "id": 3108498609,
+      "title": "add animated card",
+      "html_url": "https://github.com/layer5io/layer5/issues/6521",
+      "updated_at": "2026-04-28T15:00:36Z",
+      "labels": [
+        "kind/enhancement",
+        "help wanted",
         "good first issue",
         "language/javascript",
-        "component/ui",
-        "framework/react"
+        "framework/react",
+        "issue/remind"
       ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 2133712489,
-      "title": "[Models][UX]: Design Icon for ArgoCD Component - Event Bus",
-      "html_url": "https://github.com/meshery/meshery/issues/10297",
-      "updated_at": "2025-09-07T03:41:11Z",
+      "id": 4328078436,
+      "title": "[Sistent] Add Menu component to the sistent components page",
+      "html_url": "https://github.com/layer5io/layer5/issues/7662",
+      "updated_at": "2026-04-27T13:56:09Z",
       "labels": [
+        "kind/bug",
         "help wanted",
         "good first issue",
-        "hacktoberfest",
-        "component/ui",
-        "issue/willfix",
-        "framework/figma",
-        "area/models",
-        "type/visual-design"
+        "framework/gatsby"
       ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 2133708348,
-      "title": "[Models][UX]: Design Icon for ArgoCD Component - ArgoCD Export",
-      "html_url": "https://github.com/meshery/meshery/issues/10294",
-      "updated_at": "2025-09-06T15:39:44Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "hacktoberfest",
-        "component/ui",
-        "issue/willfix",
-        "framework/figma",
-        "area/models",
-        "type/visual-design"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 2133701189,
-      "title": "[Models][UX}: Design Icon for ArgoCD Component - ArgoCD Extension",
-      "html_url": "https://github.com/meshery/meshery/issues/10290",
-      "updated_at": "2025-09-05T04:34:45Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "hacktoberfest",
-        "component/ui",
-        "issue/willfix",
-        "framework/figma",
-        "area/models",
-        "type/visual-design"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 2923071898,
-      "title": "[mesheryctl] increase unit/integration test coverage on model subcommands",
-      "html_url": "https://github.com/meshery/meshery/issues/14042",
-      "updated_at": "2025-09-05T04:15:43Z",
-      "labels": [
-        "kind/enhancement",
-        "help wanted",
-        "good first issue",
-        "component/mesheryctl",
-        "language/go",
-        "kind/epic",
-        "area/tests"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 2618631573,
-      "title": "[Template] Create a Design Critique template",
-      "html_url": "https://github.com/meshery/meshery/issues/12502",
-      "updated_at": "2025-09-04T12:45:38Z",
-      "labels": [
-        "kind/enhancement",
-        "help wanted",
-        "good first issue",
-        "issue/willfix",
-        "component/extensions",
-        "type/visual-design"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 2618571559,
-      "title": "[Template] Create a Service blueprint template ",
-      "html_url": "https://github.com/meshery/meshery/issues/12497",
-      "updated_at": "2025-09-04T12:42:02Z",
-      "labels": [
-        "kind/enhancement",
-        "help wanted",
-        "good first issue",
-        "issue/willfix",
-        "component/extensions",
-        "type/visual-design"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 1921685352,
-      "title": "Design Error Code Reference Page in Figma to Enhance the UI ",
-      "html_url": "https://github.com/meshery/meshery/issues/8995",
-      "updated_at": "2025-08-26T00:50:56Z",
+      "id": 1876091687,
+      "title": "[Visual Design] New Recognition Badge: Event Evangelist Badge",
+      "html_url": "https://github.com/layer5io/layer5/issues/4809",
+      "updated_at": "2026-04-25T11:50:58Z",
       "labels": [
         "kind/enhancement",
         "help wanted",
         "good first issue",
         "hacktoberfest",
-        "component/ui",
-        "issue/willfix",
-        "framework/figma",
-        "type/visual-design"
+        "area/community",
+        "type/ux",
+        "issue/remind",
+        "figma",
+        "type/visual design"
       ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
-      "id": 2133710129,
-      "title": "[Models][UX]: Design Icon for ArgoCD Component - Cluster Workflow Template",
-      "html_url": "https://github.com/meshery/meshery/issues/10295",
-      "updated_at": "2025-08-26T00:47:59Z",
+      "id": 4214393939,
+      "title": "Improve styling of categories of models",
+      "html_url": "https://github.com/layer5io/layer5/issues/7593",
+      "updated_at": "2026-04-25T06:48:09Z",
       "labels": [
+        "kind/bug",
         "help wanted",
         "good first issue",
-        "hacktoberfest",
-        "component/ui",
-        "issue/willfix",
-        "framework/figma",
-        "area/models",
-        "type/visual-design"
+        "framework/gatsby",
+        "component/ui"
       ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 2618607645,
-      "title": "[Template] Create a AWS architecture template",
-      "html_url": "https://github.com/meshery/meshery/issues/12500",
-      "updated_at": "2025-08-23T17:55:04Z",
-      "labels": [
-        "kind/enhancement",
-        "help wanted",
-        "good first issue",
-        "issue/willfix",
-        "component/extensions",
-        "type/visual-design"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 3232062425,
-      "title": "[UI] Migrate Playwright extensions spec to use Playwright Page Object Model",
-      "html_url": "https://github.com/meshery/meshery/issues/15373",
-      "updated_at": "2025-08-23T10:56:16Z",
-      "labels": [
-        "kind/enhancement",
-        "good first issue",
-        "language/javascript",
-        "component/ui",
-        "framework/react"
-      ],
-      "repo": "meshery/meshery",
-      "org": "meshery",
-      "repo_name": "meshery",
-      "repo_stars": 7791,
-      "repo_forks": 2567,
-      "repo_pushed_at": "2025-09-11T17:37:42Z"
-    },
-    {
-      "id": 3402929099,
-      "title": "\"Position unavailable: \" when location off",
-      "html_url": "https://github.com/falling-fruit/falling-fruit-web/issues/866",
-      "updated_at": "2025-09-11T12:23:30Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "mobile"
-      ],
-      "repo": "falling-fruit/falling-fruit-web",
-      "org": "falling-fruit",
-      "repo_name": "falling-fruit-web",
-      "repo_stars": 61,
-      "repo_forks": 37,
-      "repo_pushed_at": "2025-09-11T17:25:37Z"
-    },
-    {
-      "id": 3391693137,
-      "title": "Make \"check confirmation email\" a separate page",
-      "html_url": "https://github.com/falling-fruit/falling-fruit-web/issues/865",
-      "updated_at": "2025-09-11T11:25:41Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "falling-fruit/falling-fruit-web",
-      "org": "falling-fruit",
-      "repo_name": "falling-fruit-web",
-      "repo_stars": 61,
-      "repo_forks": 37,
-      "repo_pushed_at": "2025-09-11T17:25:37Z"
-    },
-    {
-      "id": 2526861227,
-      "title": "fix max height of opened filter pane to just over the bottom menu icons",
-      "html_url": "https://github.com/falling-fruit/falling-fruit-web/issues/448",
-      "updated_at": "2025-08-29T06:59:37Z",
-      "labels": [
-        "good first issue",
-        "mobile"
-      ],
-      "repo": "falling-fruit/falling-fruit-web",
-      "org": "falling-fruit",
-      "repo_name": "falling-fruit-web",
-      "repo_stars": 61,
-      "repo_forks": 37,
-      "repo_pushed_at": "2025-09-11T17:25:37Z"
-    },
-    {
-      "id": 3346482561,
-      "title": "Improve experience around geolocation position uncertainty",
-      "html_url": "https://github.com/falling-fruit/falling-fruit-web/issues/860",
-      "updated_at": "2025-08-27T10:12:37Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "falling-fruit/falling-fruit-web",
-      "org": "falling-fruit",
-      "repo_name": "falling-fruit-web",
-      "repo_stars": 61,
-      "repo_forks": 37,
-      "repo_pushed_at": "2025-09-11T17:25:37Z"
-    },
-    {
-      "id": 2900305370,
-      "title": "Migrate OCC to InvitationList",
-      "html_url": "https://github.com/nextcloud/spreed/issues/14571",
-      "updated_at": "2025-09-04T13:45:04Z",
-      "labels": [
-        "1. to develop",
-        "enhancement",
-        "good first issue",
-        "feature: api 🛠️",
-        "feature: conversations 👥"
-      ],
-      "repo": "nextcloud/spreed",
-      "org": "nextcloud",
-      "repo_name": "spreed",
-      "repo_stars": 1991,
-      "repo_forks": 483,
-      "repo_pushed_at": "2025-09-11T17:25:30Z"
-    },
-    {
-      "id": 2900305288,
-      "title": "Migrate addParticipantToRoom to InvitationList",
-      "html_url": "https://github.com/nextcloud/spreed/issues/14570",
-      "updated_at": "2025-09-04T13:45:04Z",
-      "labels": [
-        "1. to develop",
-        "enhancement",
-        "good first issue",
-        "feature: api 🛠️",
-        "feature: conversations 👥"
-      ],
-      "repo": "nextcloud/spreed",
-      "org": "nextcloud",
-      "repo_name": "spreed",
-      "repo_stars": 1991,
-      "repo_forks": 483,
-      "repo_pushed_at": "2025-09-11T17:25:30Z"
-    },
-    {
-      "id": 2890996797,
-      "title": "Imprint and privacy links in public talk conversations",
-      "html_url": "https://github.com/nextcloud/spreed/issues/14547",
-      "updated_at": "2025-09-04T13:45:03Z",
-      "labels": [
-        "1. to develop",
-        "enhancement",
-        "good first issue",
-        "feature: frontend 🖌️"
-      ],
-      "repo": "nextcloud/spreed",
-      "org": "nextcloud",
-      "repo_name": "spreed",
-      "repo_stars": 1991,
-      "repo_forks": 483,
-      "repo_pushed_at": "2025-09-11T17:25:30Z"
-    },
-    {
-      "id": 1378041736,
-      "title": "Chat should permanently indicate whether message expiration is set up",
-      "html_url": "https://github.com/nextcloud/spreed/issues/7953",
-      "updated_at": "2025-09-04T13:37:27Z",
-      "labels": [
-        "1. to develop",
-        "bug",
-        "medium",
-        "good first issue",
-        "feature: chat  💬",
-        "feature: frontend 🖌️"
-      ],
-      "repo": "nextcloud/spreed",
-      "org": "nextcloud",
-      "repo_name": "spreed",
-      "repo_stars": 1991,
-      "repo_forks": 483,
-      "repo_pushed_at": "2025-09-11T17:25:30Z"
+      "repo": "layer5io/layer5",
+      "org": "layer5io",
+      "repo_name": "layer5",
+      "repo_stars": 1041,
+      "repo_forks": 1528,
+      "repo_pushed_at": "2026-05-06T00:53:44Z"
     },
     {
       "id": 617220708,
       "title": "Go back to autopilot mode if re-clicking selected participant",
       "html_url": "https://github.com/nextcloud/spreed/issues/3518",
-      "updated_at": "2025-09-04T13:35:45Z",
+      "updated_at": "2026-05-04T19:17:31Z",
       "labels": [
-        "1. to develop",
         "enhancement",
         "low",
         "good first issue",
@@ -2123,17 +1079,181 @@
       "repo": "nextcloud/spreed",
       "org": "nextcloud",
       "repo_name": "spreed",
-      "repo_stars": 1991,
-      "repo_forks": 483,
-      "repo_pushed_at": "2025-09-11T17:25:30Z"
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2900305370,
+      "title": "Migrate OCC to InvitationList",
+      "html_url": "https://github.com/nextcloud/spreed/issues/14571",
+      "updated_at": "2026-05-04T19:15:38Z",
+      "labels": [
+        "enhancement",
+        "good first issue",
+        "feature: api 🛠️",
+        "feature: conversations 👥"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2900305288,
+      "title": "Migrate addParticipantToRoom to InvitationList",
+      "html_url": "https://github.com/nextcloud/spreed/issues/14570",
+      "updated_at": "2026-05-04T19:15:38Z",
+      "labels": [
+        "enhancement",
+        "good first issue",
+        "feature: api 🛠️",
+        "feature: conversations 👥"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2890996797,
+      "title": "Imprint and privacy links in public talk conversations",
+      "html_url": "https://github.com/nextcloud/spreed/issues/14547",
+      "updated_at": "2026-05-04T19:15:37Z",
+      "labels": [
+        "enhancement",
+        "good first issue",
+        "feature: frontend 🖌️"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2599642541,
+      "title": "talk couldn't work after install the “talk_matterbridge”",
+      "html_url": "https://github.com/nextcloud/spreed/issues/13594",
+      "updated_at": "2026-04-30T12:44:29Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "feature: settings ⚙️",
+        "feature: api 🛠️",
+        "feature: frontend 🖌️",
+        "feature: integration 📦"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2319345226,
+      "title": "Limit to groups in federated target server breaks federation",
+      "html_url": "https://github.com/nextcloud/spreed/issues/12429",
+      "updated_at": "2026-04-30T12:44:10Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "feature: settings ⚙️",
+        "feature: frontend 🖌️",
+        "feature: federation 🌐"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2194798851,
+      "title": "Reactions notifications when fully subscribed in federated conversations",
+      "html_url": "https://github.com/nextcloud/spreed/issues/11857",
+      "updated_at": "2026-04-30T12:44:04Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "feature: api 🛠️",
+        "feature: federation 🌐",
+        "feature: reactions 👍"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2178491426,
+      "title": "System message shows \"guest added user\" to a conversation when adding through circle/team",
+      "html_url": "https://github.com/nextcloud/spreed/issues/11768",
+      "updated_at": "2026-04-30T12:44:03Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "feature: chat  💬",
+        "feature: api 🛠️"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2174356980,
+      "title": "Write tests for \"Team resources\" integration",
+      "html_url": "https://github.com/nextcloud/spreed/issues/11746",
+      "updated_at": "2026-04-30T12:44:02Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "feature: api 🛠️",
+        "technical debt"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
+    },
+    {
+      "id": 2659264099,
+      "title": "Temporary message added before date separator",
+      "html_url": "https://github.com/nextcloud/spreed/issues/13777",
+      "updated_at": "2026-04-30T12:43:37Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "feature: chat  💬",
+        "feature: frontend 🖌️"
+      ],
+      "repo": "nextcloud/spreed",
+      "org": "nextcloud",
+      "repo_name": "spreed",
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
     },
     {
       "id": 3107553794,
       "title": "Instant meeting outside of dashboard?",
       "html_url": "https://github.com/nextcloud/spreed/issues/15276",
-      "updated_at": "2025-08-28T14:56:31Z",
+      "updated_at": "2026-04-30T12:42:59Z",
       "labels": [
-        "1. to develop",
         "enhancement",
         "good first issue",
         "feature: frontend 🖌️",
@@ -2142,2197 +1262,2347 @@
       "repo": "nextcloud/spreed",
       "org": "nextcloud",
       "repo_name": "spreed",
-      "repo_stars": 1991,
-      "repo_forks": 483,
-      "repo_pushed_at": "2025-09-11T17:25:30Z"
+      "repo_stars": 2108,
+      "repo_forks": 528,
+      "repo_pushed_at": "2026-05-06T00:24:26Z"
     },
     {
-      "id": 2197329507,
-      "title": "Document differences between Node.js fetch() implementations and the standard",
-      "html_url": "https://github.com/nodejs/node/issues/52163",
-      "updated_at": "2025-09-03T16:15:46Z",
+      "id": 3221170131,
+      "title": "Navbar in mobile view has broken navbar position when on the list tab",
+      "html_url": "https://github.com/louislam/uptime-kuma/issues/5977",
+      "updated_at": "2026-04-23T05:03:10Z",
       "labels": [
-        "doc",
-        "good first issue"
+        "bug",
+        "good first issue",
+        "A:ui/ux"
       ],
-      "repo": "nodejs/node",
+      "repo": "louislam/uptime-kuma",
+      "org": "louislam",
+      "repo_name": "uptime-kuma",
+      "repo_stars": 86265,
+      "repo_forks": 7784,
+      "repo_pushed_at": "2026-05-06T00:18:53Z"
+    },
+    {
+      "id": 2069209060,
+      "title": "[GDPR] Add cookies consent when Google Analytics is Enabled",
+      "html_url": "https://github.com/louislam/uptime-kuma/issues/4337",
+      "updated_at": "2026-04-21T06:20:12Z",
+      "labels": [
+        "feature-request",
+        "help wanted",
+        "good first issue",
+        "A:status-page"
+      ],
+      "repo": "louislam/uptime-kuma",
+      "org": "louislam",
+      "repo_name": "uptime-kuma",
+      "repo_stars": 86265,
+      "repo_forks": 7784,
+      "repo_pushed_at": "2026-05-06T00:18:53Z"
+    },
+    {
+      "id": 2061148174,
+      "title": "GameDig Discord Server Monitoring",
+      "html_url": "https://github.com/louislam/uptime-kuma/issues/4304",
+      "updated_at": "2026-04-21T06:19:29Z",
+      "labels": [
+        "feature-request",
+        "good first issue",
+        "A:monitor",
+        "type:enhance-existing"
+      ],
+      "repo": "louislam/uptime-kuma",
+      "org": "louislam",
+      "repo_name": "uptime-kuma",
+      "repo_stars": 86265,
+      "repo_forks": 7784,
+      "repo_pushed_at": "2026-05-06T00:18:53Z"
+    },
+    {
+      "id": 4204245953,
+      "title": "Pausing a group does not pause the individual monitors of that group",
+      "html_url": "https://github.com/louislam/uptime-kuma/issues/7242",
+      "updated_at": "2026-04-09T05:18:38Z",
+      "labels": [
+        "feature-request",
+        "help wanted",
+        "good first issue",
+        "A:dashboard"
+      ],
+      "repo": "louislam/uptime-kuma",
+      "org": "louislam",
+      "repo_name": "uptime-kuma",
+      "repo_stars": 86265,
+      "repo_forks": 7784,
+      "repo_pushed_at": "2026-05-06T00:18:53Z"
+    },
+    {
+      "id": 2888041207,
+      "title": "Password Reset via CLI does not work on Embedded MariaDB",
+      "html_url": "https://github.com/louislam/uptime-kuma/issues/5670",
+      "updated_at": "2026-04-08T06:17:57Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "A:deployment"
+      ],
+      "repo": "louislam/uptime-kuma",
+      "org": "louislam",
+      "repo_name": "uptime-kuma",
+      "repo_stars": 86265,
+      "repo_forks": 7784,
+      "repo_pushed_at": "2026-05-06T00:18:53Z"
+    },
+    {
+      "id": 2304532042,
+      "title": "interceptors: move signal handling to interceptor",
+      "html_url": "https://github.com/nodejs/undici/issues/3276",
+      "updated_at": "2026-04-24T10:35:18Z",
+      "labels": [
+        "good first issue",
+        "interceptors"
+      ],
+      "repo": "nodejs/undici",
       "org": "nodejs",
-      "repo_name": "node",
-      "repo_stars": 113179,
-      "repo_forks": 33040,
-      "repo_pushed_at": "2025-09-11T17:21:57Z"
+      "repo_name": "undici",
+      "repo_stars": 7548,
+      "repo_forks": 758,
+      "repo_pushed_at": "2026-05-06T00:17:16Z"
     },
     {
-      "id": 3368849237,
-      "title": "ESM import of `http` is slower compared to CommonJS",
-      "html_url": "https://github.com/nodejs/node/issues/59686",
-      "updated_at": "2025-09-01T14:58:54Z",
-      "labels": [
-        "doc",
-        "good first issue"
-      ],
-      "repo": "nodejs/node",
-      "org": "nodejs",
-      "repo_name": "node",
-      "repo_stars": 113179,
-      "repo_forks": 33040,
-      "repo_pushed_at": "2025-09-11T17:21:57Z"
-    },
-    {
-      "id": 3400299635,
-      "title": "Get coverage testing to 100%",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/74",
-      "updated_at": "2025-09-10T16:06:00Z",
+      "id": 4359700666,
+      "title": "[ACTION] Alaiko / Zenfulfilment",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20754",
+      "updated_at": "2026-05-05T18:29:59Z",
       "labels": [
         "enhancement",
         "help wanted",
         "good first issue",
-        "testing"
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 3390987111,
-      "title": "Add image metadata for image previews",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/65",
-      "updated_at": "2025-09-08T03:03:27Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
-    },
-    {
-      "id": 3364176385,
-      "title": "improve the editor button bar",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/17",
-      "updated_at": "2025-09-07T19:51:19Z",
+      "id": 4374815794,
+      "title": "[ACTION] openai-analyze-image-content: support configurable model (gpt-4.1, gpt-5, etc.)",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20777",
+      "updated_at": "2026-05-05T17:13:58Z",
       "labels": [
         "enhancement",
         "help wanted",
         "good first issue",
-        "editor page"
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 3380460581,
-      "title": "Create and document a \"preview location\" script",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/51",
-      "updated_at": "2025-09-05T05:17:54Z",
+      "id": 4385309041,
+      "title": "[ACTION] Create item in Zoho Inventory",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20790",
+      "updated_at": "2026-05-05T15:38:36Z",
       "labels": [
         "enhancement",
         "help wanted",
         "good first issue",
-        "previews"
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 3367610517,
-      "title": "Make codemirror \"syntax highlight\" imports normal, local `/vendor` assets",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/38",
-      "updated_at": "2025-08-29T21:00:04Z",
+      "id": 4384601809,
+      "title": "[ACTION] HubSpot Meeting Scheduler APIs",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20789",
+      "updated_at": "2026-05-05T13:54:10Z",
       "labels": [
         "enhancement",
         "help wanted",
-        "good first issue"
+        "good first issue",
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 3365021221,
-      "title": "add starter project for 11y",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/29",
-      "updated_at": "2025-08-29T16:45:13Z",
+      "id": 4380811659,
+      "title": "[ACTION] Apollo.io Search APIs",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20787",
+      "updated_at": "2026-05-05T01:21:10Z",
       "labels": [
+        "enhancement",
         "help wanted",
         "good first issue",
-        "starter projects"
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 3365022615,
-      "title": "add a flask server starter",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/31",
-      "updated_at": "2025-08-29T00:12:44Z",
+      "id": 4170561179,
+      "title": "[ACTION] Remove Specific Label Function in Pipedrive",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20431",
+      "updated_at": "2026-05-04T09:30:51Z",
       "labels": [
+        "enhancement",
         "help wanted",
         "good first issue",
-        "starter projects"
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 3365021830,
-      "title": "add starter project for vite",
-      "html_url": "https://github.com/Pomax/make-webbly-things/issues/30",
-      "updated_at": "2025-08-29T00:12:40Z",
+      "id": 4374840261,
+      "title": "[ACTION] Zoho Desk - List Ticket Fields, List Departments",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20778",
+      "updated_at": "2026-05-04T07:47:10Z",
       "labels": [
+        "enhancement",
         "help wanted",
         "good first issue",
-        "starter projects"
+        "action"
       ],
-      "repo": "Pomax/make-webbly-things",
-      "org": "Pomax",
-      "repo_name": "make-webbly-things",
-      "repo_stars": 8,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T18:18:40Z"
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
     },
     {
-      "id": 1013665954,
-      "title": "ARIA in HTML allowances changes for br and wbr",
-      "html_url": "https://github.com/dequelabs/axe-core/issues/3177",
-      "updated_at": "2025-09-11T19:30:44Z",
+      "id": 4366983697,
+      "title": "[ACTION]",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20773",
+      "updated_at": "2026-05-01T22:43:21Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4331343868,
+      "title": "[ACTION] Huntress new actions",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20703",
+      "updated_at": "2026-05-01T21:55:05Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4353671841,
+      "title": "[ACTION] [App] Ringba — request for additional pre-built components",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20743",
+      "updated_at": "2026-05-01T21:54:27Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4354267654,
+      "title": "[ACTIONS] Trolley - Add core actions for recipient and payout workflows",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20750",
+      "updated_at": "2026-05-01T21:53:57Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4345983953,
+      "title": "[ACTION] Databricks - Feature parity with the api key version",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20719",
+      "updated_at": "2026-05-01T21:53:34Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged",
+        "HIGH PRIORITY"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4364627997,
+      "title": "[ACTION] MEWS get bills and fetch rates",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20762",
+      "updated_at": "2026-05-01T17:22:05Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4317465026,
+      "title": "[ACTION] Statuspage - Fetch Active Incidents, Fetch Components, and Create/update maintenances",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20688",
+      "updated_at": "2026-05-01T13:15:56Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4277227128,
+      "title": "Tools for nexudus mcp",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20623",
+      "updated_at": "2026-04-23T19:24:40Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4300327516,
+      "title": "[ACTION]",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20659",
+      "updated_at": "2026-04-23T19:23:24Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4315042570,
+      "title": "[ACTION] Shopify - get tracking",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20684",
+      "updated_at": "2026-04-23T15:53:31Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4120291919,
+      "title": "[ACTION] teamleader update ticket",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20357",
+      "updated_at": "2026-04-21T20:20:25Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4236398494,
+      "title": "[ACTION] New Moodle actions",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20554",
+      "updated_at": "2026-04-21T18:33:04Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4202488291,
+      "title": "[components] Hedy",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20510",
+      "updated_at": "2026-04-17T16:26:34Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "trigger / source"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4220878227,
+      "title": "[ACTION] Microsoft teams upload image affordance",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20536",
+      "updated_at": "2026-04-17T16:25:10Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4220761266,
+      "title": "[ACTION] Hiver new actions",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20534",
+      "updated_at": "2026-04-17T16:24:25Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4220905446,
+      "title": "[ACTION] Simplify Notion upload image affordance",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20537",
+      "updated_at": "2026-04-17T16:06:40Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 4263727208,
+      "title": "[ACTION] New Lever Actions",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20599",
+      "updated_at": "2026-04-17T16:06:09Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 2591764859,
+      "title": "[TRIGGER] Discord new messages in thread",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/14309",
+      "updated_at": "2026-04-17T05:15:15Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "trigger / source",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 2805269390,
+      "title": "[shopify files upload] [Shopify Files section under Content Menu]",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/15367",
+      "updated_at": "2026-04-17T05:14:26Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 2806395477,
+      "title": "[FEATURE] Update Runware integration",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/15378",
+      "updated_at": "2026-04-17T05:13:45Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 3061899240,
+      "title": "[TRIGGER] watch a row",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/16656",
+      "updated_at": "2026-04-17T05:13:04Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "question",
+        "trigger / source",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 3077639009,
+      "title": "New Apollo recording available",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/16725",
+      "updated_at": "2026-04-17T05:12:14Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "question",
+        "trigger / source",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 2836386666,
+      "title": "[ACTIONS] Procore - Direct Costs API",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/15515",
+      "updated_at": "2026-04-17T04:50:43Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "trigger / source",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 3069470691,
+      "title": "[ACTION] notion - update page",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/16697",
+      "updated_at": "2026-04-17T04:50:08Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "question",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 3535918892,
+      "title": "[ACTION] Add CoinAPI MCP Server integration",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/18821",
+      "updated_at": "2026-04-17T04:48:57Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "app",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 3938476404,
+      "title": "[ACTION] Get DPD parcel status",
+      "html_url": "https://github.com/PipedreamHQ/pipedream/issues/20027",
+      "updated_at": "2026-04-10T18:53:43Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue",
+        "action",
+        "triaged"
+      ],
+      "repo": "PipedreamHQ/pipedream",
+      "org": "PipedreamHQ",
+      "repo_name": "pipedream",
+      "repo_stars": 11310,
+      "repo_forks": 5649,
+      "repo_pushed_at": "2026-05-06T00:04:57Z"
+    },
+    {
+      "id": 3236737182,
+      "title": "Update channel_authorize to reflect that it's restricted like other signing methods",
+      "html_url": "https://github.com/XRPLF/xrpl-dev-portal/issues/3197",
+      "updated_at": "2026-04-09T17:21:09Z",
       "labels": [
         "good first issue",
-        "standards"
-      ],
-      "repo": "dequelabs/axe-core",
-      "org": "dequelabs",
-      "repo_name": "axe-core",
-      "repo_stars": 6592,
-      "repo_forks": 839,
-      "repo_pushed_at": "2025-09-11T17:04:42Z"
-    },
-    {
-      "id": 3222419032,
-      "title": "Ensure all user facing instances of \"consent mode\" to be lowercase / sentence case.",
-      "html_url": "https://github.com/google/site-kit-wp/issues/11076",
-      "updated_at": "2025-09-04T13:11:28Z",
-      "labels": [
-        "Type: Support",
-        "P2",
-        "Type: Enhancement",
-        "Good First Issue"
-      ],
-      "repo": "google/site-kit-wp",
-      "org": "google",
-      "repo_name": "site-kit-wp",
-      "repo_stars": 1323,
-      "repo_forks": 318,
-      "repo_pushed_at": "2025-09-11T17:57:24Z"
-    },
-    {
-      "id": 3243434228,
-      "title": "Simplify inline module data handling.",
-      "html_url": "https://github.com/google/site-kit-wp/issues/11120",
-      "updated_at": "2025-08-20T15:10:29Z",
-      "labels": [
-        "P2",
-        "Type: Enhancement",
-        "Good First Issue",
-        "PHP"
-      ],
-      "repo": "google/site-kit-wp",
-      "org": "google",
-      "repo_name": "site-kit-wp",
-      "repo_stars": 1323,
-      "repo_forks": 318,
-      "repo_pushed_at": "2025-09-11T17:57:24Z"
-    },
-    {
-      "id": 3381388705,
-      "title": "Language selector should sort language output",
-      "html_url": "https://github.com/openedx/frontend-app-account/issues/1338",
-      "updated_at": "2025-09-03T21:40:45Z",
-      "labels": [
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "openedx/frontend-app-account",
-      "org": "openedx",
-      "repo_name": "frontend-app-account",
-      "repo_stars": 22,
-      "repo_forks": 162,
-      "repo_pushed_at": "2025-09-11T17:00:54Z"
-    },
-    {
-      "id": 3381332304,
-      "title": "Language selector drop down should not list languages for which we don't have a translation file",
-      "html_url": "https://github.com/openedx/frontend-app-account/issues/1337",
-      "updated_at": "2025-09-03T21:18:11Z",
-      "labels": [
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "openedx/frontend-app-account",
-      "org": "openedx",
-      "repo_name": "frontend-app-account",
-      "repo_stars": 22,
-      "repo_forks": 162,
-      "repo_pushed_at": "2025-09-11T17:00:54Z"
-    },
-    {
-      "id": 3326105310,
-      "title": "Remove common fields from ledger entry reference tables",
-      "html_url": "https://github.com/XRPLF/xrpl-dev-portal/issues/3238",
-      "updated_at": "2025-08-18T18:15:09Z",
-      "labels": [
-        "good first issue",
-        "organization"
+        "content updates",
+        "payments"
       ],
       "repo": "XRPLF/xrpl-dev-portal",
       "org": "XRPLF",
       "repo_name": "xrpl-dev-portal",
-      "repo_stars": 1460,
-      "repo_forks": 1100,
-      "repo_pushed_at": "2025-09-11T16:55:07Z"
+      "repo_stars": 1874,
+      "repo_forks": 1156,
+      "repo_pushed_at": "2026-05-05T23:57:17Z"
     },
     {
-      "id": 3340683813,
-      "title": "[Docs] Convert Static Image to Meshery Design - 3",
-      "html_url": "https://github.com/layer5io/docs/issues/793",
-      "updated_at": "2025-09-04T14:25:19Z",
+      "id": 3339991819,
+      "title": "DeveloperError: Must define either _workerName or _workerPath for asynchronous geometry.",
+      "html_url": "https://github.com/CesiumGS/cesium/issues/12826",
+      "updated_at": "2026-04-27T19:17:38Z",
       "labels": [
-        "area/docs",
+        "type - cleanup",
+        "category - doc",
         "good first issue",
-        "help wanted",
-        "language/markdown",
-        "framework/hugo"
+        "category - polygons/geometry"
       ],
-      "repo": "layer5io/docs",
-      "org": "layer5io",
-      "repo_name": "docs",
-      "repo_stars": 74,
-      "repo_forks": 133,
-      "repo_pushed_at": "2025-09-11T16:36:02Z"
+      "repo": "CesiumGS/cesium",
+      "org": "CesiumGS",
+      "repo_name": "cesium",
+      "repo_stars": 15231,
+      "repo_forks": 3787,
+      "repo_pushed_at": "2026-05-05T23:23:13Z"
     },
     {
-      "id": 3340691618,
-      "title": "[Docs] Convert Static Image to Meshery Design - 4",
-      "html_url": "https://github.com/layer5io/docs/issues/794",
-      "updated_at": "2025-09-04T10:01:41Z",
+      "id": 2072624863,
+      "title": "Ongoing documentation fixes",
+      "html_url": "https://github.com/CesiumGS/cesium/issues/11749",
+      "updated_at": "2026-04-08T10:43:03Z",
       "labels": [
-        "area/docs",
+        "category - doc",
         "good first issue",
-        "help wanted",
-        "language/markdown",
-        "framework/hugo"
+        "onramping",
+        "JTC"
       ],
-      "repo": "layer5io/docs",
-      "org": "layer5io",
-      "repo_name": "docs",
-      "repo_stars": 74,
-      "repo_forks": 133,
-      "repo_pushed_at": "2025-09-11T16:36:02Z"
+      "repo": "CesiumGS/cesium",
+      "org": "CesiumGS",
+      "repo_name": "cesium",
+      "repo_stars": 15231,
+      "repo_forks": 3787,
+      "repo_pushed_at": "2026-05-05T23:23:13Z"
     },
     {
-      "id": 3302872128,
-      "title": "[Docs] Convert Static Image to Meshery Design - 1",
-      "html_url": "https://github.com/layer5io/docs/issues/759",
-      "updated_at": "2025-08-28T21:43:29Z",
+      "id": 4387935129,
+      "title": "Fix JavaScript lint errors",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11958",
+      "updated_at": "2026-05-06T01:15:21Z",
       "labels": [
-        "area/docs",
+        "Good First Issue"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4380611239,
+      "title": "Fix JavaScript lint errors",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11936",
+      "updated_at": "2026-05-05T00:29:22Z",
+      "labels": [
+        "Good First Issue"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4370457790,
+      "title": "Fix TypeScript declarations lint errors",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11896",
+      "updated_at": "2026-05-04T15:57:14Z",
+      "labels": [
+        "Good First Issue"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4362159920,
+      "title": "Fix broken Markdown link: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11868",
+      "updated_at": "2026-05-01T00:45:18Z",
+      "labels": [
+        "Good First Issue"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4362117987,
+      "title": "Fix JavaScript lint errors",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11867",
+      "updated_at": "2026-05-01T00:31:39Z",
+      "labels": [
+        "Good First Issue"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4329609697,
+      "title": "Fix JavaScript lint errors",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11784",
+      "updated_at": "2026-04-26T07:46:20Z",
+      "labels": [
+        "Good First Issue"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4239076591,
+      "title": "[RFC]: Migrate `math/base/special` packages from relative tolerance testing to ULP difference testing (tracking issue)",
+      "html_url": "https://github.com/stdlib-js/stdlib/issues/11352",
+      "updated_at": "2026-04-14T17:55:19Z",
+      "labels": [
+        "difficulty: 1",
+        "Math",
+        "Tests",
+        "Accepted",
+        "Good First Issue",
+        "priority: Normal",
+        "JavaScript",
+        "Modernization"
+      ],
+      "repo": "stdlib-js/stdlib",
+      "org": "stdlib-js",
+      "repo_name": "stdlib",
+      "repo_stars": 5820,
+      "repo_forks": 1178,
+      "repo_pushed_at": "2026-05-06T03:03:33Z"
+    },
+    {
+      "id": 4090684737,
+      "title": "FAQ database: Add content: What happens to my submitted, but not-yet-approved, TDM Plan if the TDM Program Guidelines change?",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3018",
+      "updated_at": "2026-05-06T02:25:06Z",
+      "labels": [
         "good first issue",
-        "help wanted",
-        "language/markdown",
-        "framework/hugo"
+        "p-feature: FAQ",
+        "priority: MUST HAVE",
+        "role: Product Management",
+        "time sensitive",
+        "size: 0.25pt",
+        "role: ux content writing",
+        "deck: stakeholder presentation",
+        "deck: staging",
+        "Participant type: User",
+        "p-feature: FAQ content"
       ],
-      "repo": "layer5io/docs",
-      "org": "layer5io",
-      "repo_name": "docs",
-      "repo_stars": 74,
-      "repo_forks": 133,
-      "repo_pushed_at": "2025-09-11T16:36:02Z"
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
     },
     {
-      "id": 3332431302,
-      "title": "[Docs] Outdataed images in \"Cloning a Design\"",
-      "html_url": "https://github.com/layer5io/docs/issues/785",
-      "updated_at": "2025-08-22T12:32:42Z",
+      "id": 3584014804,
+      "title": "FAQ database: How to Submit a Snapshot",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/2754",
+      "updated_at": "2026-05-06T02:20:23Z",
       "labels": [
-        "area/docs",
         "good first issue",
-        "help wanted",
-        "language/markdown",
-        "framework/hugo"
+        "p-feature: FAQ",
+        "priority: MUST HAVE",
+        "role: Product Management",
+        "Waiting on Stakeholder",
+        "size: 0.25pt",
+        "p-feature: Submissions and process",
+        "p-feature: snapshot",
+        "deck: stakeholder presentation",
+        "deck: staging",
+        "Participant type: User"
       ],
-      "repo": "layer5io/docs",
-      "org": "layer5io",
-      "repo_name": "docs",
-      "repo_stars": 74,
-      "repo_forks": 133,
-      "repo_pushed_at": "2025-09-11T16:36:02Z"
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
     },
     {
-      "id": 3332246425,
-      "title": "[Docs] Academy: Example use of REST APIs",
-      "html_url": "https://github.com/layer5io/docs/issues/784",
-      "updated_at": "2025-08-19T17:07:43Z",
+      "id": 4091004272,
+      "title": "FAQ database: Add content: How do I make revisions to my submitted TDM Plan that were requested by LADOT?",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3023",
+      "updated_at": "2026-05-06T02:17:55Z",
       "labels": [
-        "area/docs",
         "good first issue",
-        "help wanted",
-        "language/go",
-        "language/javascript",
-        "language/markdown",
-        "framework/hugo"
+        "level: easy",
+        "p-feature: FAQ",
+        "priority: MUST HAVE",
+        "role: Product Management",
+        "dependency",
+        "size: 0.25pt",
+        "role: ux content writing",
+        "deck: stakeholder presentation",
+        "deck: staging",
+        "Participant type: User",
+        "p-feature: FAQ content"
       ],
-      "repo": "layer5io/docs",
-      "org": "layer5io",
-      "repo_name": "docs",
-      "repo_stars": 74,
-      "repo_forks": 133,
-      "repo_pushed_at": "2025-09-11T16:36:02Z"
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
     },
     {
-      "id": 3314472074,
-      "title": "Addition of rag Chatbot",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/226",
-      "updated_at": "2025-09-07T05:59:23Z",
+      "id": 4090938875,
+      "title": "FAQ database: Add content: I have an approved TDM Plan and my building has a Certificate of Occupancy. How do I modify my TDM Plan?",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3022",
+      "updated_at": "2026-05-06T01:43:47Z",
       "labels": [
-        "documentation",
+        "good first issue",
+        "level: easy",
+        "p-feature: FAQ",
+        "priority: MUST HAVE",
+        "role: Product Management",
+        "status: to update!",
+        "size: 0.25pt",
+        "role: ux content writing",
+        "deck: stakeholder presentation",
+        "deck: staging",
+        "Participant type: User",
+        "p-feature: FAQ content"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 4387466048,
+      "title": "Dev: Update the spelling linter exclusion list with new terms",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3167",
+      "updated_at": "2026-05-06T00:07:00Z",
+      "labels": [
+        "good first issue",
+        "role: front-end",
+        "priority: MUST HAVE",
+        "time sensitive",
+        "size: 0.25pt",
+        "ready for dev lead",
+        "deck: add to staging",
+        "feature: spelling"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 4097558849,
+      "title": "DEV: External links should open consistently across all pages.",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3029",
+      "updated_at": "2026-04-28T09:01:16Z",
+      "labels": [
+        "good first issue",
+        "role: front-end",
+        "priority: SHOULD HAVE",
+        "p-feature: About",
+        "size: 2pt",
+        "deck: staging"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 4240619437,
+      "title": "Bug: field focus on Page 1 is incorrect",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3109",
+      "updated_at": "2026-04-23T20:11:50Z",
+      "labels": [
+        "bug",
+        "good first issue",
+        "role: front-end",
+        "priority: MUST HAVE",
+        "p-feature: Project Page p1",
+        "size: 0.25pt",
+        "deck: staging"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 4091162330,
+      "title": "FAQ database: Add content: How do I revise my proposed TDM Plan while keeping the same version of the Program Guidelines as my original submission?",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3024",
+      "updated_at": "2026-04-23T17:47:06Z",
+      "labels": [
+        "good first issue",
+        "level: easy",
+        "p-feature: FAQ",
+        "priority: MUST HAVE",
+        "role: Product Management",
+        "dependency",
+        "size: 0.25pt",
+        "role: ux content writing",
+        "deck: stakeholder presentation",
+        "deck: staging",
+        "Participant type: User",
+        "p-feature: FAQ content"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 4181574580,
+      "title": "Dev: Update text when there are no results on Submissions page",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/3078",
+      "updated_at": "2026-04-18T19:48:00Z",
+      "labels": [
+        "good first issue",
+        "role: front-end",
+        "level: easy",
+        "priority: SHOULD HAVE",
+        "size: 0.5pt",
+        "p-feature: Submissions and process",
+        "deck: staging"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 3568531864,
+      "title": "FAQ database: Add content: How can I search and filter my projects",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/2744",
+      "updated_at": "2026-04-15T19:42:32Z",
+      "labels": [
+        "good first issue",
+        "level: easy",
+        "p-feature: FAQ",
+        "priority: MUST HAVE",
+        "role: Product Management",
+        "dependency",
+        "time sensitive",
+        "size: 0.25pt",
+        "deck: stakeholder presentation",
+        "Participant type: User",
+        "p-feature: FAQ content"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 3169134000,
+      "title": "Dev: Fix column heading alignment and Date format on Security page",
+      "html_url": "https://github.com/hackforla/tdm-calculator/issues/2580",
+      "updated_at": "2026-04-09T20:40:24Z",
+      "labels": [
+        "good first issue",
+        "role: front-end",
+        "priority: MUST HAVE",
+        "ready for product",
+        "size: 0.25pt",
+        "p-feature: Security",
+        "deck: staging",
+        "Participant Type: Security Admin"
+      ],
+      "repo": "hackforla/tdm-calculator",
+      "org": "hackforla",
+      "repo_name": "tdm-calculator",
+      "repo_stars": 64,
+      "repo_forks": 47,
+      "repo_pushed_at": "2026-05-05T23:07:15Z"
+    },
+    {
+      "id": 4350721839,
+      "title": "feat(game): role marker should allow exact-searches",
+      "html_url": "https://github.com/UltiMafia/Ultimafia/issues/2774",
+      "updated_at": "2026-04-29T13:00:06Z",
+      "labels": [
+        "enhancement",
+        "good first issue"
+      ],
+      "repo": "UltiMafia/Ultimafia",
+      "org": "UltiMafia",
+      "repo_name": "Ultimafia",
+      "repo_stars": 29,
+      "repo_forks": 53,
+      "repo_pushed_at": "2026-05-05T23:06:15Z"
+    },
+    {
+      "id": 4262253278,
+      "title": "[Feature] Add `Warning` and `info` toast types.",
+      "html_url": "https://github.com/younisdev/dyvix-ui/issues/100",
+      "updated_at": "2026-04-14T13:09:38Z",
+      "labels": [
+        "enhancement",
+        "help wanted",
+        "good first issue"
+      ],
+      "repo": "younisdev/dyvix-ui",
+      "org": "younisdev",
+      "repo_name": "dyvix-ui",
+      "repo_stars": 4,
+      "repo_forks": 11,
+      "repo_pushed_at": "2026-05-05T22:43:21Z"
+    },
+    {
+      "id": 4250328132,
+      "title": "[Chore] Move toast position styles into there own positions.css",
+      "html_url": "https://github.com/younisdev/dyvix-ui/issues/96",
+      "updated_at": "2026-04-12T23:41:42Z",
+      "labels": [
+        "help wanted",
+        "good first issue"
+      ],
+      "repo": "younisdev/dyvix-ui",
+      "org": "younisdev",
+      "repo_name": "dyvix-ui",
+      "repo_stars": 4,
+      "repo_forks": 11,
+      "repo_pushed_at": "2026-05-05T22:43:21Z"
+    },
+    {
+      "id": 3053092095,
+      "title": "Create more MSDF fonts to put in q5's fonts folder",
+      "html_url": "https://github.com/q5js/q5.js/issues/123",
+      "updated_at": "2026-05-03T11:38:27Z",
+      "labels": [
+        "help wanted",
+        "good first issue"
+      ],
+      "repo": "q5js/q5.js",
+      "org": "q5js",
+      "repo_name": "q5.js",
+      "repo_stars": 404,
+      "repo_forks": 21,
+      "repo_pushed_at": "2026-05-05T22:35:19Z"
+    },
+    {
+      "id": 4266587172,
+      "title": "Table style presets (theme picker)",
+      "html_url": "https://github.com/carnworkstudios/TAFNE/issues/7",
+      "updated_at": "2026-04-15T05:55:41Z",
+      "labels": [
+        "enhancement",
+        "good first issue"
+      ],
+      "repo": "carnworkstudios/TAFNE",
+      "org": "carnworkstudios",
+      "repo_name": "TAFNE",
+      "repo_stars": 1,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T22:35:06Z"
+    },
+    {
+      "id": 4251245360,
+      "title": "Handle Global Undo/Redo across Mode Switches",
+      "html_url": "https://github.com/carnworkstudios/TAFNE/issues/4",
+      "updated_at": "2026-04-13T04:24:20Z",
+      "labels": [
+        "bug",
+        "good first issue"
+      ],
+      "repo": "carnworkstudios/TAFNE",
+      "org": "carnworkstudios",
+      "repo_name": "TAFNE",
+      "repo_stars": 1,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T22:35:06Z"
+    },
+    {
+      "id": 4251235989,
+      "title": "Export Node Graph as SVG/PNG",
+      "html_url": "https://github.com/carnworkstudios/TAFNE/issues/3",
+      "updated_at": "2026-04-13T04:21:38Z",
+      "labels": [
         "enhancement",
         "good first issue",
-        "Component",
-        "Level 3",
-        "gssoc25",
-        "frontend",
+        "node-editor"
+      ],
+      "repo": "carnworkstudios/TAFNE",
+      "org": "carnworkstudios",
+      "repo_name": "TAFNE",
+      "repo_stars": 1,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T22:35:06Z"
+    },
+    {
+      "id": 4381312536,
+      "title": "Add onboarding welcome screen for new users",
+      "html_url": "https://github.com/OREL-group/Project-Management/issues/216",
+      "updated_at": "2026-05-05T09:53:19Z",
+      "labels": [
+        "good first issue"
+      ],
+      "repo": "OREL-group/Project-Management",
+      "org": "OREL-group",
+      "repo_name": "Project-Management",
+      "repo_stars": 0,
+      "repo_forks": 31,
+      "repo_pushed_at": "2026-05-05T22:33:05Z"
+    },
+    {
+      "id": 4279614973,
+      "title": "make a Start Here guide for plugin setup",
+      "html_url": "https://github.com/OREL-group/Project-Management/issues/123",
+      "updated_at": "2026-04-17T01:53:37Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "OREL-group/Project-Management",
+      "org": "OREL-group",
+      "repo_name": "Project-Management",
+      "repo_stars": 0,
+      "repo_forks": 31,
+      "repo_pushed_at": "2026-05-05T22:33:05Z"
+    },
+    {
+      "id": 4277027858,
+      "title": "reaching out to investors",
+      "html_url": "https://github.com/OREL-group/Project-Management/issues/95",
+      "updated_at": "2026-04-16T16:16:20Z",
+      "labels": [
+        "good first issue",
+        "Rescoping",
+        "Metrics"
+      ],
+      "repo": "OREL-group/Project-Management",
+      "org": "OREL-group",
+      "repo_name": "Project-Management",
+      "repo_stars": 0,
+      "repo_forks": 31,
+      "repo_pushed_at": "2026-05-05T22:33:05Z"
+    },
+    {
+      "id": 4276891111,
+      "title": "create a organized database for the prototype",
+      "html_url": "https://github.com/OREL-group/Project-Management/issues/90",
+      "updated_at": "2026-04-16T15:54:02Z",
+      "labels": [
+        "good first issue",
+        "Design",
+        "Backend Dev"
+      ],
+      "repo": "OREL-group/Project-Management",
+      "org": "OREL-group",
+      "repo_name": "Project-Management",
+      "repo_stars": 0,
+      "repo_forks": 31,
+      "repo_pushed_at": "2026-05-05T22:33:05Z"
+    },
+    {
+      "id": 4250057653,
+      "title": "Finalize Design Sprint Objectives",
+      "html_url": "https://github.com/OREL-group/Project-Management/issues/50",
+      "updated_at": "2026-04-14T20:02:35Z",
+      "labels": [
+        "good first issue",
+        "presentation",
+        "Design"
+      ],
+      "repo": "OREL-group/Project-Management",
+      "org": "OREL-group",
+      "repo_name": "Project-Management",
+      "repo_stars": 0,
+      "repo_forks": 31,
+      "repo_pushed_at": "2026-05-05T22:33:05Z"
+    },
+    {
+      "id": 4215728542,
+      "title": "Discover who we need to hire for the project",
+      "html_url": "https://github.com/OREL-group/Project-Management/issues/39",
+      "updated_at": "2026-04-07T05:50:07Z",
+      "labels": [
+        "good first issue"
+      ],
+      "repo": "OREL-group/Project-Management",
+      "org": "OREL-group",
+      "repo_name": "Project-Management",
+      "repo_stars": 0,
+      "repo_forks": 31,
+      "repo_pushed_at": "2026-05-05T22:33:05Z"
+    },
+    {
+      "id": 4386362277,
+      "title": "bug: hardcoded referral code placeholder in WelcomeOnline.jsx",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/12",
+      "updated_at": "2026-05-05T19:58:55Z",
+      "labels": [
+        "bug",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 4386364559,
+      "title": "enhancement: add PropTypes validation to shared UI components",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/14",
+      "updated_at": "2026-05-05T18:47:40Z",
+      "labels": [
+        "enhancement",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 4386363803,
+      "title": "chore: migrate wiki-seed docs from repo into the GitHub wiki",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/13",
+      "updated_at": "2026-05-05T18:47:31Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 4386361402,
+      "title": "docs: fill in Architecture section in documentation/README.md",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/11",
+      "updated_at": "2026-05-05T18:47:05Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 4386360703,
+      "title": "chore: add CONTRIBUTING.md with contributor guidelines",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/10",
+      "updated_at": "2026-05-05T18:46:57Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 4386359972,
+      "title": "chore: add a LICENSE file to the repository",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/9",
+      "updated_at": "2026-05-05T18:46:49Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 4386358723,
+      "title": "docs: replace OmniCore references with StreamerOps in documentation",
+      "html_url": "https://github.com/LOLinDark/StreamerOps/issues/8",
+      "updated_at": "2026-05-05T18:46:36Z",
+      "labels": [
+        "documentation",
+        "good first issue"
+      ],
+      "repo": "LOLinDark/StreamerOps",
+      "org": "LOLinDark",
+      "repo_name": "StreamerOps",
+      "repo_stars": 0,
+      "repo_forks": 2,
+      "repo_pushed_at": "2026-05-05T21:42:59Z"
+    },
+    {
+      "id": 615913469,
+      "title": "Custom Pitch block's pie menu is reversed, no rotation, and no pitch preview",
+      "html_url": "https://github.com/sugarlabs/musicblocks/issues/2255",
+      "updated_at": "2026-05-03T17:35:57Z",
+      "labels": [
+        "Priority-Minor",
+        "Good first issue"
+      ],
+      "repo": "sugarlabs/musicblocks",
+      "org": "sugarlabs",
+      "repo_name": "musicblocks",
+      "repo_stars": 839,
+      "repo_forks": 1602,
+      "repo_pushed_at": "2026-05-05T21:35:47Z"
+    },
+    {
+      "id": 4226952511,
+      "title": "Don't compose strings with internationalizations",
+      "html_url": "https://github.com/OSC/ondemand/issues/5293",
+      "updated_at": "2026-04-28T18:50:30Z",
+      "labels": [
+        "good first issue",
+        "area/locales"
+      ],
+      "repo": "OSC/ondemand",
+      "org": "OSC",
+      "repo_name": "ondemand",
+      "repo_stars": 453,
+      "repo_forks": 179,
+      "repo_pushed_at": "2026-05-05T20:36:03Z"
+    },
+    {
+      "id": 796119738,
+      "title": "default MOTD",
+      "html_url": "https://github.com/OSC/ondemand/issues/866",
+      "updated_at": "2026-04-20T14:18:16Z",
+      "labels": [
+        "category/enhancement",
+        "good first issue",
+        "component/dashboard"
+      ],
+      "repo": "OSC/ondemand",
+      "org": "OSC",
+      "repo_name": "ondemand",
+      "repo_stars": 453,
+      "repo_forks": 179,
+      "repo_pushed_at": "2026-05-05T20:36:03Z"
+    },
+    {
+      "id": 521679592,
+      "title": "ActiveJobs: Show job submission time.",
+      "html_url": "https://github.com/OSC/ondemand/issues/132",
+      "updated_at": "2026-04-10T23:16:21Z",
+      "labels": [
+        "category/enhancement",
+        "good first issue",
+        "component/active_jobs",
+        "priority/maybe"
+      ],
+      "repo": "OSC/ondemand",
+      "org": "OSC",
+      "repo_name": "ondemand",
+      "repo_stars": 453,
+      "repo_forks": 179,
+      "repo_pushed_at": "2026-05-05T20:36:03Z"
+    },
+    {
+      "id": 4217451929,
+      "title": "`--resource-type` is used by more than just `ls`",
+      "html_url": "https://github.com/dbt-labs/docs.getdbt.com/issues/8908",
+      "updated_at": "2026-04-22T18:47:32Z",
+      "labels": [
+        "content",
+        "good first issue",
+        "improvement"
+      ],
+      "repo": "dbt-labs/docs.getdbt.com",
+      "org": "dbt-labs",
+      "repo_name": "docs.getdbt.com",
+      "repo_stars": 196,
+      "repo_forks": 1154,
+      "repo_pushed_at": "2026-05-05T22:18:00Z"
+    },
+    {
+      "id": 3928551230,
+      "title": "fail fast docs only mentions `run` but works for `build` and `test` too",
+      "html_url": "https://github.com/dbt-labs/docs.getdbt.com/issues/8584",
+      "updated_at": "2026-04-16T22:05:35Z",
+      "labels": [
+        "content",
+        "good first issue",
+        "improvement"
+      ],
+      "repo": "dbt-labs/docs.getdbt.com",
+      "org": "dbt-labs",
+      "repo_name": "docs.getdbt.com",
+      "repo_stars": 196,
+      "repo_forks": 1154,
+      "repo_pushed_at": "2026-05-05T22:18:00Z"
+    },
+    {
+      "id": 2349159065,
+      "title": "[Core] Configurability of the timestamps in logs",
+      "html_url": "https://github.com/dbt-labs/docs.getdbt.com/issues/5651",
+      "updated_at": "2026-04-16T22:02:08Z",
+      "labels": [
+        "content",
+        "good first issue",
+        "size: medium",
+        "dbt Core"
+      ],
+      "repo": "dbt-labs/docs.getdbt.com",
+      "org": "dbt-labs",
+      "repo_name": "docs.getdbt.com",
+      "repo_stars": 196,
+      "repo_forks": 1154,
+      "repo_pushed_at": "2026-05-05T22:18:00Z"
+    },
+    {
+      "id": 1126544066,
+      "title": "Badge request: SDKMAN",
+      "html_url": "https://github.com/badges/shields/issues/7581",
+      "updated_at": "2026-04-22T04:20:18Z",
+      "labels": [
+        "good first issue",
+        "service-badge"
+      ],
+      "repo": "badges/shields",
+      "org": "badges",
+      "repo_name": "shields",
+      "repo_stars": 26551,
+      "repo_forks": 5588,
+      "repo_pushed_at": "2026-05-05T20:20:49Z"
+    },
+    {
+      "id": 2290469197,
+      "title": "Azure DevOps - Build Badge - PAT Token not used on private projects",
+      "html_url": "https://github.com/badges/shields/issues/10162",
+      "updated_at": "2026-04-06T14:45:17Z",
+      "labels": [
+        "good first issue",
+        "service-badge"
+      ],
+      "repo": "badges/shields",
+      "org": "badges",
+      "repo_name": "shields",
+      "repo_stars": 26551,
+      "repo_forks": 5588,
+      "repo_pushed_at": "2026-05-05T20:20:49Z"
+    },
+    {
+      "id": 3141543517,
+      "title": "Anchor tags on homepage doesn't highlight the tab for that part of the page.",
+      "html_url": "https://github.com/wikispeedruns/wikipedia-speedruns/issues/625",
+      "updated_at": "2026-04-27T19:18:42Z",
+      "labels": [
+        "bug: minor",
         "UI",
-        "feature",
-        "backend",
-        "authentication",
-        "AI",
-        "data-visualization",
-        "Navigation"
+        "UX",
+        "good first issue"
       ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
+      "repo": "wikispeedruns/wikipedia-speedruns",
+      "org": "wikispeedruns",
+      "repo_name": "wikipedia-speedruns",
+      "repo_stars": 134,
+      "repo_forks": 43,
+      "repo_pushed_at": "2026-05-05T20:05:22Z"
     },
     {
-      "id": 3389151538,
-      "title": "[Bug] Server error during student registration",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/465",
-      "updated_at": "2025-09-06T10:50:50Z",
+      "id": 1552295253,
+      "title": "Array constructor with length is not eliminated",
+      "html_url": "https://github.com/google/closure-compiler/issues/4046",
+      "updated_at": "2026-04-13T18:20:10Z",
       "labels": [
-        "good first issue",
-        "Level 2",
-        "gssoc25"
-      ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
-    },
-    {
-      "id": 3356810173,
-      "title": "Mouse bubble effect causes lag and disrupts UX",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/378",
-      "updated_at": "2025-08-27T06:16:45Z",
-      "labels": [
-        "good first issue",
-        "Level 1",
-        "gssoc25"
-      ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
-    },
-    {
-      "id": 3287203054,
-      "title": "Css issue in mobile view",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/188",
-      "updated_at": "2025-08-22T09:21:49Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "Component",
-        "Level 1",
-        "gssoc25",
-        "frontend",
-        "feature",
-        "Navigation"
-      ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
-    },
-    {
-      "id": 3320880680,
-      "title": "404 Error on Page Refresh for SPA Routes in Production",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/238",
-      "updated_at": "2025-08-17T16:40:54Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "Level 2",
-        "gssoc25",
-        "backend",
-        "authentication",
-        "Navigation"
-      ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
-    },
-    {
-      "id": 3283481792,
-      "title": "Feature: Add Pagination & Filtering to Dashboard Listings",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/164",
-      "updated_at": "2025-08-17T02:19:20Z",
-      "labels": [
-        "documentation",
-        "enhancement",
-        "good first issue",
-        "Component",
-        "Level 2",
-        "gssoc25",
-        "frontend",
-        "UI",
-        "feature",
-        "animation",
-        "routing"
-      ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
-    },
-    {
-      "id": 3317445095,
-      "title": "fix(ui): ensure scroll-to-top button doesn’t overlap chatbot icon",
-      "html_url": "https://github.com/MonishRaman/Placify-Smarter_Placements-Sharper_Talent/issues/234",
-      "updated_at": "2025-08-14T18:20:14Z",
-      "labels": [
-        "bug",
-        "enhancement",
-        "good first issue",
-        "Component",
-        "Level 1",
-        "gssoc25",
-        "frontend",
-        "UI",
-        "feature",
-        "animation"
-      ],
-      "repo": "MonishRaman/Placify-Smarter_Placements-Sharper_Talent",
-      "org": "MonishRaman",
-      "repo_name": "Placify-Smarter_Placements-Sharper_Talent",
-      "repo_stars": 27,
-      "repo_forks": 67,
-      "repo_pushed_at": "2025-09-11T16:31:03Z"
-    },
-    {
-      "id": 3355681279,
-      "title": "Add \"Wishlist\" Feature to Allow Users to Save Books",
-      "html_url": "https://github.com/arjavjain5203/Pustak_Ghar/issues/79",
-      "updated_at": "2025-08-28T12:19:04Z",
-      "labels": [
-        "good first issue",
-        "LEVEL 1"
-      ],
-      "repo": "arjavjain5203/Pustak_Ghar",
-      "org": "arjavjain5203",
-      "repo_name": "Pustak_Ghar",
-      "repo_stars": 6,
-      "repo_forks": 41,
-      "repo_pushed_at": "2025-09-11T16:30:22Z"
-    },
-    {
-      "id": 3327626144,
-      "title": "Resource Rating System",
-      "html_url": "https://github.com/arjavjain5203/Pustak_Ghar/issues/52",
-      "updated_at": "2025-08-26T03:43:29Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "GSSoC'25",
-        "LEVEL 3"
-      ],
-      "repo": "arjavjain5203/Pustak_Ghar",
-      "org": "arjavjain5203",
-      "repo_name": "Pustak_Ghar",
-      "repo_stars": 6,
-      "repo_forks": 41,
-      "repo_pushed_at": "2025-09-11T16:30:22Z"
-    },
-    {
-      "id": 3330596324,
-      "title": "Enhancing the UI, adding of the Feedback from, login and Signup pages",
-      "html_url": "https://github.com/arjavjain5203/Pustak_Ghar/issues/61",
-      "updated_at": "2025-08-22T15:34:35Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "GSSoC'25",
-        "LEVEL 3"
-      ],
-      "repo": "arjavjain5203/Pustak_Ghar",
-      "org": "arjavjain5203",
-      "repo_name": "Pustak_Ghar",
-      "repo_stars": 6,
-      "repo_forks": 41,
-      "repo_pushed_at": "2025-09-11T16:30:22Z"
-    },
-    {
-      "id": 3324968985,
-      "title": "Adding Footer and functionality  to the \"More\" & \"Join\" option in home page",
-      "html_url": "https://github.com/arjavjain5203/Pustak_Ghar/issues/40",
-      "updated_at": "2025-08-17T13:59:08Z",
-      "labels": [
-        "good first issue",
-        "GSSoC'25",
-        "LEVEL 1"
-      ],
-      "repo": "arjavjain5203/Pustak_Ghar",
-      "org": "arjavjain5203",
-      "repo_name": "Pustak_Ghar",
-      "repo_stars": 6,
-      "repo_forks": 41,
-      "repo_pushed_at": "2025-09-11T16:30:22Z"
-    },
-    {
-      "id": 3312695626,
-      "title": "Feature: Global Resource Search & Quick Access",
-      "html_url": "https://github.com/arjavjain5203/Pustak_Ghar/issues/19",
-      "updated_at": "2025-08-15T16:44:21Z",
-      "labels": [
-        "good first issue",
-        "GSSoC'25",
-        "LEVEL 2"
-      ],
-      "repo": "arjavjain5203/Pustak_Ghar",
-      "org": "arjavjain5203",
-      "repo_name": "Pustak_Ghar",
-      "repo_stars": 6,
-      "repo_forks": 41,
-      "repo_pushed_at": "2025-09-11T16:30:22Z"
-    },
-    {
-      "id": 3317650280,
-      "title": "✉️ Add Contact Form with EmailJS Integration",
-      "html_url": "https://github.com/arjavjain5203/Pustak_Ghar/issues/26",
-      "updated_at": "2025-08-15T09:12:42Z",
-      "labels": [
-        "good first issue",
-        "GSSoC'25",
-        "beginner",
-        "LEVEL 1"
-      ],
-      "repo": "arjavjain5203/Pustak_Ghar",
-      "org": "arjavjain5203",
-      "repo_name": "Pustak_Ghar",
-      "repo_stars": 6,
-      "repo_forks": 41,
-      "repo_pushed_at": "2025-09-11T16:30:22Z"
-    },
-    {
-      "id": 3382737909,
-      "title": "[Bug] Poor Visibility & UI Problems on Product Description Page",
-      "html_url": "https://github.com/agamjotsingh18/trendhora/issues/221",
-      "updated_at": "2025-09-07T12:30:35Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "gssoc25",
-        "Level2"
-      ],
-      "repo": "agamjotsingh18/trendhora",
-      "org": "agamjotsingh18",
-      "repo_name": "trendhora",
-      "repo_stars": 11,
-      "repo_forks": 68,
-      "repo_pushed_at": "2025-09-11T16:27:43Z"
-    },
-    {
-      "id": 3260608182,
-      "title": "Search Functionality",
-      "html_url": "https://github.com/agamjotsingh18/trendhora/issues/16",
-      "updated_at": "2025-09-01T19:19:36Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "gssoc25",
-        "Level2"
-      ],
-      "repo": "agamjotsingh18/trendhora",
-      "org": "agamjotsingh18",
-      "repo_name": "trendhora",
-      "repo_stars": 11,
-      "repo_forks": 68,
-      "repo_pushed_at": "2025-09-11T16:27:43Z"
-    },
-    {
-      "id": 3339174900,
-      "title": "[Feature]  Design Custom 404 Error Page with Navigation to Home",
-      "html_url": "https://github.com/agamjotsingh18/trendhora/issues/180",
-      "updated_at": "2025-08-20T21:03:46Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "gssoc25",
-        "Level2"
-      ],
-      "repo": "agamjotsingh18/trendhora",
-      "org": "agamjotsingh18",
-      "repo_name": "trendhora",
-      "repo_stars": 11,
-      "repo_forks": 68,
-      "repo_pushed_at": "2025-09-11T16:27:43Z"
-    },
-    {
-      "id": 3325261660,
-      "title": "[Bug] Warning: Each child in a list should have a unique “key” prop in ShopCategory component",
-      "html_url": "https://github.com/agamjotsingh18/trendhora/issues/154",
-      "updated_at": "2025-08-16T06:07:37Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "gssoc25",
-        "Level2"
-      ],
-      "repo": "agamjotsingh18/trendhora",
-      "org": "agamjotsingh18",
-      "repo_name": "trendhora",
-      "repo_stars": 11,
-      "repo_forks": 68,
-      "repo_pushed_at": "2025-09-11T16:27:43Z"
-    },
-    {
-      "id": 3267307328,
-      "title": "Feature Request: Add Mega Menu for Gender-Based Navigation",
-      "html_url": "https://github.com/agamjotsingh18/trendhora/issues/37",
-      "updated_at": "2025-08-12T20:08:37Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "gssoc25",
-        "Level2",
-        "Frontend"
-      ],
-      "repo": "agamjotsingh18/trendhora",
-      "org": "agamjotsingh18",
-      "repo_name": "trendhora",
-      "repo_stars": 11,
-      "repo_forks": 68,
-      "repo_pushed_at": "2025-09-11T16:27:43Z"
-    },
-    {
-      "id": 3405232164,
-      "title": "Create a new file SECURITY.md for the github repo.",
-      "html_url": "https://github.com/Roshansuthar1105/Codify/issues/353",
-      "updated_at": "2025-09-11T13:18:50Z",
-      "labels": [
-        "documentation",
-        "good first issue",
-        "gssoc25",
-        "Level 2",
-        "Not assigned yet"
-      ],
-      "repo": "Roshansuthar1105/Codify",
-      "org": "Roshansuthar1105",
-      "repo_name": "Codify",
-      "repo_stars": 34,
-      "repo_forks": 76,
-      "repo_pushed_at": "2025-09-11T16:22:54Z"
-    },
-    {
-      "id": 3361686712,
-      "title": "Issue: Request to Add Notes for a New Subject",
-      "html_url": "https://github.com/Roshansuthar1105/Codify/issues/139",
-      "updated_at": "2025-08-31T06:13:34Z",
-      "labels": [
-        "documentation",
-        "enhancement",
         "help wanted",
         "good first issue",
-        "gssoc25",
-        "Not assigned yet"
+        "P4",
+        "feat"
       ],
-      "repo": "Roshansuthar1105/Codify",
-      "org": "Roshansuthar1105",
-      "repo_name": "Codify",
-      "repo_stars": 34,
-      "repo_forks": 76,
-      "repo_pushed_at": "2025-09-11T16:22:54Z"
+      "repo": "google/closure-compiler",
+      "org": "google",
+      "repo_name": "closure-compiler",
+      "repo_stars": 7649,
+      "repo_forks": 1176,
+      "repo_pushed_at": "2026-05-05T19:59:47Z"
     },
     {
-      "id": 3362799572,
-      "title": "Links for address and mail",
-      "html_url": "https://github.com/Roshansuthar1105/Codify/issues/147",
-      "updated_at": "2025-08-31T06:00:46Z",
+      "id": 3966486736,
+      "title": "Remove unused functions",
+      "html_url": "https://github.com/oss-slu/DigitalBoneBox/issues/274",
+      "updated_at": "2026-05-03T04:16:42Z",
       "labels": [
-        "documentation",
         "enhancement",
+        "good first issue"
+      ],
+      "repo": "oss-slu/DigitalBoneBox",
+      "org": "oss-slu",
+      "repo_name": "DigitalBoneBox",
+      "repo_stars": 4,
+      "repo_forks": 15,
+      "repo_pushed_at": "2026-05-05T19:42:43Z"
+    },
+    {
+      "id": 3872963855,
+      "title": "Label toggle",
+      "html_url": "https://github.com/oss-slu/DigitalBoneBox/issues/233",
+      "updated_at": "2026-04-11T17:06:58Z",
+      "labels": [
+        "enhancement",
+        "good first issue"
+      ],
+      "repo": "oss-slu/DigitalBoneBox",
+      "org": "oss-slu",
+      "repo_name": "DigitalBoneBox",
+      "repo_stars": 4,
+      "repo_forks": 15,
+      "repo_pushed_at": "2026-05-05T19:42:43Z"
+    },
+    {
+      "id": 4374561489,
+      "title": "perf: lazy-load card detail panel",
+      "html_url": "https://github.com/sabbah13/cowork-tasks/issues/30",
+      "updated_at": "2026-05-05T09:00:41Z",
+      "labels": [
+        "help wanted",
         "good first issue",
-        "gssoc25",
-        "Level 1"
+        "performance"
       ],
-      "repo": "Roshansuthar1105/Codify",
-      "org": "Roshansuthar1105",
-      "repo_name": "Codify",
-      "repo_stars": 34,
-      "repo_forks": 76,
-      "repo_pushed_at": "2025-09-11T16:22:54Z"
+      "repo": "sabbah13/cowork-tasks",
+      "org": "sabbah13",
+      "repo_name": "cowork-tasks",
+      "repo_stars": 4,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T21:00:27Z"
     },
     {
-      "id": 3347469560,
-      "title": "Incorrect Video Thumbnail Displayed in Java Section",
-      "html_url": "https://github.com/Roshansuthar1105/Codify/issues/60",
-      "updated_at": "2025-08-26T02:35:32Z",
+      "id": 4374561865,
+      "title": "a11y: keyboard navigation audit + fixes",
+      "html_url": "https://github.com/sabbah13/cowork-tasks/issues/32",
+      "updated_at": "2026-05-04T06:55:17Z",
       "labels": [
-        "enhancement",
+        "help wanted",
         "good first issue",
-        "gssoc25",
-        "Level 2"
+        "a11y"
       ],
-      "repo": "Roshansuthar1105/Codify",
-      "org": "Roshansuthar1105",
-      "repo_name": "Codify",
-      "repo_stars": 34,
-      "repo_forks": 76,
-      "repo_pushed_at": "2025-09-11T16:22:54Z"
+      "repo": "sabbah13/cowork-tasks",
+      "org": "sabbah13",
+      "repo_name": "cowork-tasks",
+      "repo_stars": 4,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T21:00:27Z"
     },
     {
-      "id": 2738804511,
-      "title": "[Feature] Add default provider in config file",
-      "html_url": "https://github.com/eduardconstantin/storybook-genie/issues/39",
-      "updated_at": "2025-08-18T15:39:51Z",
+      "id": 4374561766,
+      "title": "i18n: scaffolding for German and Japanese",
+      "html_url": "https://github.com/sabbah13/cowork-tasks/issues/31",
+      "updated_at": "2026-05-04T06:55:15Z",
       "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "eduardconstantin/storybook-genie",
-      "org": "eduardconstantin",
-      "repo_name": "storybook-genie",
-      "repo_stars": 107,
-      "repo_forks": 12,
-      "repo_pushed_at": "2025-09-11T16:15:48Z"
-    },
-    {
-      "id": 3277966626,
-      "title": "SYSHUB001v2-SG01 | Improved voting buttons",
-      "html_url": "https://github.com/syscoin/syshub/issues/102",
-      "updated_at": "2025-09-11T02:05:13Z",
-      "labels": [
-        "enhancement",
+        "help wanted",
         "good first issue",
-        "In Progress"
+        "i18n"
       ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
+      "repo": "sabbah13/cowork-tasks",
+      "org": "sabbah13",
+      "repo_name": "cowork-tasks",
+      "repo_stars": 4,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T21:00:27Z"
     },
     {
-      "id": 3277968064,
-      "title": "SYSHUB001v2-SG03 | Update label from \"IP Address\" to \"IP Address (without port)\"",
-      "html_url": "https://github.com/syscoin/syshub/issues/104",
-      "updated_at": "2025-09-11T02:02:56Z",
-      "labels": [
-        "enhancement",
-        "good first issue",
-        "In Progress"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3305242364,
-      "title": "SYSHUB001v3-ER05 | Collateral Hash governance redirects to chainz.cryptoid.info",
-      "html_url": "https://github.com/syscoin/syshub/issues/118",
-      "updated_at": "2025-09-05T13:56:46Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "Dev Tested"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3277917801,
-      "title": "SYSHUB001v1-SG01 | Outdated SentryNode requirements on \"About\" page",
-      "html_url": "https://github.com/syscoin/syshub/issues/80",
-      "updated_at": "2025-09-02T17:56:58Z",
-      "labels": [
-        "good first issue"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3277934247,
-      "title": "SYSHUB001v1-ER13 | Links to the outdated article",
-      "html_url": "https://github.com/syscoin/syshub/issues/92",
-      "updated_at": "2025-09-02T17:46:38Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3277935703,
-      "title": "SYSHUB001v1-ER15 | The \"About\" section should link to \"/stats\"",
-      "html_url": "https://github.com/syscoin/syshub/issues/94",
-      "updated_at": "2025-09-02T17:45:54Z",
-      "labels": [
-        "bug",
-        "good first issue"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3277936270,
-      "title": "SYSHUB001v1-ER16 | Links to the outdated article",
-      "html_url": "https://github.com/syscoin/syshub/issues/95",
-      "updated_at": "2025-09-02T17:43:40Z",
-      "labels": [
-        "bug",
-        "good first issue"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3277937236,
-      "title": "SYSHUB001v1-ER17 | Links to the outdated article",
-      "html_url": "https://github.com/syscoin/syshub/issues/96",
-      "updated_at": "2025-09-02T17:43:12Z",
-      "labels": [
-        "good first issue"
-      ],
-      "repo": "syscoin/syshub",
-      "org": "syscoin",
-      "repo_name": "syshub",
-      "repo_stars": 5,
-      "repo_forks": 4,
-      "repo_pushed_at": "2025-09-11T16:14:35Z"
-    },
-    {
-      "id": 3406643607,
-      "title": "Add New Properties to `City` class",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/13",
-      "updated_at": "2025-09-11T19:11:59Z",
+      "id": 4374559053,
+      "title": "feat: snooze-until-tomorrow card action",
+      "html_url": "https://github.com/sabbah13/cowork-tasks/issues/29",
+      "updated_at": "2026-05-04T06:54:43Z",
       "labels": [
         "enhancement",
         "help wanted",
         "good first issue"
       ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
+      "repo": "sabbah13/cowork-tasks",
+      "org": "sabbah13",
+      "repo_name": "cowork-tasks",
+      "repo_stars": 4,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T21:00:27Z"
     },
     {
-      "id": 3395359532,
-      "title": "Store Food on each Tile",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/4",
-      "updated_at": "2025-09-11T16:42:03Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3400041491,
-      "title": "Home Page Needed",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/12",
-      "updated_at": "2025-09-11T14:18:23Z",
+      "id": 4374558961,
+      "title": "docs: 'first 5 minutes' walkthrough with screenshots",
+      "html_url": "https://github.com/sabbah13/cowork-tasks/issues/28",
+      "updated_at": "2026-05-04T06:54:41Z",
       "labels": [
         "documentation",
         "help wanted",
         "good first issue"
       ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3399541267,
-      "title": "Switch to use Phaser.js Tilemap Layers",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/9",
-      "updated_at": "2025-09-11T13:27:11Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "refactor"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3399002132,
-      "title": "Add fog-of-war",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/5",
-      "updated_at": "2025-09-09T18:57:04Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3399355601,
-      "title": "Add Blog Section to Website",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/8",
-      "updated_at": "2025-09-09T17:36:18Z",
-      "labels": [
-        "documentation",
-        "good first issue"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3399037540,
-      "title": "Split `Player` class into `Nation` and `Faction` classes",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/7",
-      "updated_at": "2025-09-09T15:55:34Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "refactor"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3395072835,
-      "title": "Main Menu Needed",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/2",
-      "updated_at": "2025-09-08T18:19:59Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3395091712,
-      "title": "Title Screen Needed",
-      "html_url": "https://github.com/YodasWs/Empires-4x/issues/3",
-      "updated_at": "2025-09-08T17:46:16Z",
-      "labels": [
-        "enhancement",
-        "help wanted",
-        "good first issue"
-      ],
-      "repo": "YodasWs/Empires-4x",
-      "org": "YodasWs",
-      "repo_name": "Empires-4x",
-      "repo_stars": 0,
-      "repo_forks": 2,
-      "repo_pushed_at": "2025-09-11T16:10:16Z"
-    },
-    {
-      "id": 3091157360,
-      "title": "PDFs with a \"blob:\" URL cannot be saved on desktop or iOS",
-      "html_url": "https://github.com/brave/brave-browser/issues/46348",
-      "updated_at": "2025-09-08T14:17:42Z",
-      "labels": [
-        "good first issue",
-        "priority/P4",
-        "OS/Desktop",
-        "OS/iOS"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 2923180489,
-      "title": "Huge unnecessarily long scrollbar on `brave://settings/content/all`",
-      "html_url": "https://github.com/brave/brave-browser/issues/44696",
-      "updated_at": "2025-09-05T15:42:08Z",
-      "labels": [
-        "good first issue",
-        "priority/P5",
-        "feature/settings",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3365079033,
-      "title": "Purple background behind search and keyboard elements",
-      "html_url": "https://github.com/brave/brave-browser/issues/48812",
-      "updated_at": "2025-09-04T15:37:08Z",
-      "labels": [
-        "good first issue",
-        "OS/iOS"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3368298198,
-      "title": "Closing a tab from the Tabs Bar will occasionally fail",
-      "html_url": "https://github.com/brave/brave-browser/issues/48847",
-      "updated_at": "2025-09-04T15:33:54Z",
-      "labels": [
-        "good first issue",
-        "OS/iOS"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3248053329,
-      "title": "Save button doesn't have bottom padding when Developer mode is enabled in Shields settings",
-      "html_url": "https://github.com/brave/brave-browser/issues/47782",
-      "updated_at": "2025-09-02T15:55:35Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "feature/user-interface",
-        "priority/P4",
-        "QA/Yes",
-        "release-notes/include",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 495946541,
-      "title": "Remove `Dashboard Settings` tool tip for each stats",
-      "html_url": "https://github.com/brave/brave-browser/issues/6084",
-      "updated_at": "2025-08-31T17:13:46Z",
-      "labels": [
-        "bug",
-        "good first issue",
-        "feature/user-interface",
-        "priority/P4",
-        "QA/Yes",
-        "QA/Test-Plan-Specified"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 2641581918,
-      "title": "Incorrect icon for Bookmarks in side panel",
-      "html_url": "https://github.com/brave/brave-browser/issues/42163",
-      "updated_at": "2025-08-27T16:20:40Z",
-      "labels": [
-        "good first issue",
-        "polish",
-        "priority/P5",
-        "misc/icons",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 2588973387,
-      "title": "Brave wordmark should be bold",
-      "html_url": "https://github.com/brave/brave-browser/issues/41637",
-      "updated_at": "2025-08-26T16:48:53Z",
-      "labels": [
-        "good first issue",
-        "polish",
-        "priority/P5",
-        "QA/No",
-        "release-notes/exclude",
-        "branding",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3036203956,
-      "title": "outline of drop downs on print modal isn't visible enough in dark theme - follow up to 45532",
-      "html_url": "https://github.com/brave/brave-browser/issues/45815",
-      "updated_at": "2025-08-24T11:25:12Z",
-      "labels": [
-        "help wanted",
-        "good first issue",
-        "polish",
-        "priority/P5",
-        "QA/Yes",
-        "feature/settings",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3226652124,
-      "title": "Reader Mode Custom Fonts",
-      "html_url": "https://github.com/brave/brave-browser/issues/47598",
-      "updated_at": "2025-08-22T13:51:34Z",
-      "labels": [
-        "good first issue",
-        "priority/P5",
-        "feature-request",
-        "feature/speedreader",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 1309192288,
-      "title": "Clicking on `Filter lists` opens up the filter page in a new tab even though the filter page already opened in another tab",
-      "html_url": "https://github.com/brave/brave-browser/issues/24120",
-      "updated_at": "2025-08-20T00:44:27Z",
-      "labels": [
-        "good first issue",
-        "suggestion",
-        "priority/P4",
-        "QA/Yes",
-        "QA/Test-Plan-Specified",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3212273698,
-      "title": "Split view - Fixes to gap menu button",
-      "html_url": "https://github.com/brave/brave-browser/issues/47451",
-      "updated_at": "2025-08-18T11:23:05Z",
-      "labels": [
-        "good first issue",
-        "polish",
-        "priority/P4",
-        "OS/Desktop",
-        "split view"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3274237009,
-      "title": "`See the brave difference` CTA sometimes is still displayed when quickly tapping on the `omnibox`",
-      "html_url": "https://github.com/brave/brave-browser/issues/48002",
-      "updated_at": "2025-08-17T19:49:51Z",
-      "labels": [
-        "good first issue",
-        "QA/Yes",
-        "release-notes/include",
-        "onboarding",
-        "OS/iOS"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 2721215763,
-      "title": "Add styling to brave://certificate-manager/",
-      "html_url": "https://github.com/brave/brave-browser/issues/42705",
-      "updated_at": "2025-08-15T19:56:54Z",
-      "labels": [
-        "good first issue",
-        "design",
-        "priority/P4",
-        "QA/Yes",
-        "release-notes/include",
-        "OS/Desktop"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 2788554977,
-      "title": "[AI Chat]: Reorder functions in `ai_chat_service.cc` to match order in header file",
-      "html_url": "https://github.com/brave/brave-browser/issues/43294",
-      "updated_at": "2025-08-15T09:53:48Z",
-      "labels": [
-        "good first issue",
-        "priority/P3",
-        "QA/No",
-        "dev-concern",
-        "release-notes/exclude",
-        "browser-ai"
-      ],
-      "repo": "brave/brave-browser",
-      "org": "brave",
-      "repo_name": "brave-browser",
-      "repo_stars": 20149,
-      "repo_forks": 2731,
-      "repo_pushed_at": "2025-09-11T16:05:25Z"
-    },
-    {
-      "id": 3407202297,
-      "title": "Setup redux",
-      "html_url": "https://github.com/plushexe351/codepain/issues/12",
-      "updated_at": "2025-09-11T17:53:17Z",
-      "labels": [
-        "enhancement",
-        "good first issue"
-      ],
-      "repo": "plushexe351/codepain",
-      "org": "plushexe351",
-      "repo_name": "codepain",
-      "repo_stars": 0,
-      "repo_forks": 0,
-      "repo_pushed_at": "2025-09-11T16:02:04Z"
-    },
-    {
-      "id": 3407303380,
-      "title": "Setup MUI (Material UI)",
-      "html_url": "https://github.com/plushexe351/codepain/issues/13",
-      "updated_at": "2025-09-11T16:37:23Z",
-      "labels": [
-        "good first issue",
-        "UI"
-      ],
-      "repo": "plushexe351/codepain",
-      "org": "plushexe351",
-      "repo_name": "codepain",
-      "repo_stars": 0,
-      "repo_forks": 0,
-      "repo_pushed_at": "2025-09-11T16:02:04Z"
-    },
-    {
-      "id": 3176151524,
-      "title": "Add optional tiles border on exported PDF",
-      "html_url": "https://github.com/cboard-org/cboard/issues/1954",
-      "updated_at": "2025-08-18T18:16:57Z",
-      "labels": [
-        "good first issue",
-        "enhancement"
-      ],
-      "repo": "cboard-org/cboard",
-      "org": "cboard-org",
-      "repo_name": "cboard",
-      "repo_stars": 708,
-      "repo_forks": 231,
-      "repo_pushed_at": "2025-09-11T16:01:29Z"
-    },
-    {
-      "id": 2249705008,
-      "title": "createInterpolateElement: Add error handling in case unmatched tags are included",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/60843",
-      "updated_at": "2025-09-09T13:27:57Z",
-      "labels": [
-        "[Type] Bug",
-        "Good First Issue",
-        "[Status] In Progress",
-        "[Package] Element"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 2676118469,
-      "title": "Storybook: Add and Update Block Editor Components stories",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/67165",
-      "updated_at": "2025-08-31T12:43:08Z",
-      "labels": [
-        "[Type] Developer Documentation",
-        "Good First Issue",
-        "[Type] Tracking Issue",
-        "Storybook"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 2130186747,
-      "title": "Command Palette: Prevent third-party plugins from crashing the editor.",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/58939",
-      "updated_at": "2025-08-28T22:26:20Z",
-      "labels": [
-        "[Type] Enhancement",
-        "Good First Issue",
-        "[Package] Commands"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 858017016,
-      "title": "Scripts: Try using cosmiconf for locating tool configs ",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/30842",
-      "updated_at": "2025-08-27T13:28:22Z",
-      "labels": [
-        "[Type] Enhancement",
-        "Good First Issue",
-        "Needs Dev",
-        "[Tool] WP Scripts"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 1778090811,
-      "title": "Dropdown active option indicator misaligned",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/52001",
-      "updated_at": "2025-08-23T12:43:56Z",
-      "labels": [
-        "Good First Issue",
-        "[Priority] Low",
-        "[Type] Regression",
-        "Mobile App - i.e. Android or iOS"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 1926749606,
-      "title": "Use lowercase capitalization on Featured Image \"Link to...\" control",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/55057",
-      "updated_at": "2025-08-20T21:03:19Z",
-      "labels": [
-        "Good First Issue",
-        "[Status] In Progress",
-        "Internationalization (i18n)",
-        "[Type] Copy",
-        "[Block] Post Featured Image",
-        "[Status] In discussion"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 2977459565,
-      "title": "Duotone Filter Not Updating on Style Variation Change in Site Editor for Template Part",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/69847",
-      "updated_at": "2025-08-19T17:19:52Z",
-      "labels": [
-        "[Type] Bug",
-        "Good First Issue",
-        "[Status] In Progress",
-        "Global Styles"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 924136307,
-      "title": "Gradient backgrounds should be set with `background-image` instead of `background`",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/32787",
-      "updated_at": "2025-08-18T07:56:09Z",
-      "labels": [
-        "[Type] Enhancement",
-        "Good First Issue",
-        "[Status] In Progress",
-        "CSS Styling"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
-    },
-    {
-      "id": 2271485296,
-      "title": "Add ESLint rule to prevent usage of the order CSS property",
-      "html_url": "https://github.com/WordPress/gutenberg/issues/61247",
-      "updated_at": "2025-08-12T01:38:09Z",
-      "labels": [
-        "[Focus] Accessibility (a11y)",
-        "Good First Issue",
-        "[Status] In Progress",
-        "[Type] Code Quality"
-      ],
-      "repo": "WordPress/gutenberg",
-      "org": "WordPress",
-      "repo_name": "gutenberg",
-      "repo_stars": 11387,
-      "repo_forks": 4552,
-      "repo_pushed_at": "2025-09-11T16:28:56Z"
+      "repo": "sabbah13/cowork-tasks",
+      "org": "sabbah13",
+      "repo_name": "cowork-tasks",
+      "repo_stars": 4,
+      "repo_forks": 1,
+      "repo_pushed_at": "2026-05-05T21:00:27Z"
     }
   ],
   "org_summaries": {
-    "brisbanesocialchess": {
+    "naimkatiman": {
       "total_repos": 1,
-      "total_stars": 16,
-      "total_forks": 44,
-      "recent_issues_count": 13,
-      "activity_frequency": 13,
-      "popularity_score": 104
+      "total_stars": 3,
+      "total_forks": 4,
+      "recent_issues_count": 9,
+      "activity_frequency": 9,
+      "popularity_score": 11
     },
-    "layer5io": {
+    "cdxgen": {
+      "total_repos": 1,
+      "total_stars": 956,
+      "total_forks": 245,
+      "recent_issues_count": 1,
+      "activity_frequency": 1,
+      "popularity_score": 1446
+    },
+    "WordPress": {
+      "total_repos": 1,
+      "total_stars": 11629,
+      "total_forks": 4791,
+      "recent_issues_count": 8,
+      "activity_frequency": 8,
+      "popularity_score": 21211
+    },
+    "vercel": {
+      "total_repos": 1,
+      "total_stars": 139286,
+      "total_forks": 31020,
+      "recent_issues_count": 5,
+      "activity_frequency": 5,
+      "popularity_score": 201326
+    },
+    "nodejs": {
       "total_repos": 2,
-      "total_stars": 1022,
-      "total_forks": 1509,
-      "recent_issues_count": 13,
-      "activity_frequency": 6.5,
-      "popularity_score": 4040
+      "total_stars": 124591,
+      "total_forks": 36240,
+      "recent_issues_count": 8,
+      "activity_frequency": 4,
+      "popularity_score": 197071
     },
-    "MLH-Fellowship": {
+    "HarperFast": {
+      "total_repos": 1,
+      "total_stars": 75,
+      "total_forks": 5,
+      "recent_issues_count": 3,
+      "activity_frequency": 3,
+      "popularity_score": 85
+    },
+    "nextcloud": {
+      "total_repos": 2,
+      "total_stars": 2313,
+      "total_forks": 569,
+      "recent_issues_count": 12,
+      "activity_frequency": 6,
+      "popularity_score": 3451
+    },
+    "medic": {
+      "total_repos": 1,
+      "total_stars": 537,
+      "total_forks": 382,
+      "recent_issues_count": 6,
+      "activity_frequency": 6,
+      "popularity_score": 1301
+    },
+    "meshery": {
+      "total_repos": 1,
+      "total_stars": 755,
+      "total_forks": 782,
+      "recent_issues_count": 1,
+      "activity_frequency": 1,
+      "popularity_score": 2319
+    },
+    "LovelyStoOk": {
       "total_repos": 1,
       "total_stars": 0,
       "total_forks": 0,
-      "recent_issues_count": 4,
-      "activity_frequency": 4,
+      "recent_issues_count": 2,
+      "activity_frequency": 2,
       "popularity_score": 0
     },
     "HeyPuter": {
       "total_repos": 1,
-      "total_stars": 36129,
-      "total_forks": 2806,
-      "recent_issues_count": 32,
-      "activity_frequency": 32,
-      "popularity_score": 41741
-    },
-    "vercel": {
-      "total_repos": 1,
-      "total_stars": 134344,
-      "total_forks": 29291,
+      "total_stars": 40925,
+      "total_forks": 3719,
       "recent_issues_count": 2,
       "activity_frequency": 2,
-      "popularity_score": 192926
+      "popularity_score": 48363
     },
-    "layer5labs": {
+    "layer5io": {
       "total_repos": 1,
-      "total_stars": 49,
-      "total_forks": 69,
-      "recent_issues_count": 1,
-      "activity_frequency": 1,
-      "popularity_score": 187
+      "total_stars": 1041,
+      "total_forks": 1528,
+      "recent_issues_count": 16,
+      "activity_frequency": 16,
+      "popularity_score": 4097
     },
-    "NMRLipids": {
+    "louislam": {
       "total_repos": 1,
-      "total_stars": 1,
-      "total_forks": 3,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 7
-    },
-    "WordPress": {
-      "total_repos": 2,
-      "total_stars": 13179,
-      "total_forks": 4887,
-      "recent_issues_count": 10,
+      "total_stars": 86265,
+      "total_forks": 7784,
+      "recent_issues_count": 5,
       "activity_frequency": 5,
-      "popularity_score": 22953
-    },
-    "Hylozoic": {
-      "total_repos": 1,
-      "total_stars": 13,
-      "total_forks": 3,
-      "recent_issues_count": 1,
-      "activity_frequency": 1,
-      "popularity_score": 19
-    },
-    "open-webui": {
-      "total_repos": 1,
-      "total_stars": 109581,
-      "total_forks": 14993,
-      "recent_issues_count": 1,
-      "activity_frequency": 1,
-      "popularity_score": 139567
-    },
-    "eccentriccoder01": {
-      "total_repos": 1,
-      "total_stars": 7,
-      "total_forks": 15,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 37
+      "popularity_score": 101833
     },
     "PipedreamHQ": {
       "total_repos": 1,
-      "total_stars": 10556,
-      "total_forks": 5490,
-      "recent_issues_count": 19,
-      "activity_frequency": 19,
-      "popularity_score": 21536
-    },
-    "eyaltoledano": {
-      "total_repos": 1,
-      "total_stars": 21871,
-      "total_forks": 2128,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 26127
-    },
-    "open-telemetry": {
-      "total_repos": 1,
-      "total_stars": 762,
-      "total_forks": 1516,
-      "recent_issues_count": 8,
-      "activity_frequency": 8,
-      "popularity_score": 3794
-    },
-    "sveltejs": {
-      "total_repos": 1,
-      "total_stars": 84066,
-      "total_forks": 4613,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 93292
-    },
-    "meshery": {
-      "total_repos": 1,
-      "total_stars": 7791,
-      "total_forks": 2567,
-      "recent_issues_count": 11,
-      "activity_frequency": 11,
-      "popularity_score": 12925
-    },
-    "falling-fruit": {
-      "total_repos": 1,
-      "total_stars": 61,
-      "total_forks": 37,
-      "recent_issues_count": 4,
-      "activity_frequency": 4,
-      "popularity_score": 135
-    },
-    "nextcloud": {
-      "total_repos": 1,
-      "total_stars": 1991,
-      "total_forks": 483,
-      "recent_issues_count": 6,
-      "activity_frequency": 6,
-      "popularity_score": 2957
-    },
-    "nodejs": {
-      "total_repos": 1,
-      "total_stars": 113179,
-      "total_forks": 33040,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 179259
-    },
-    "Pomax": {
-      "total_repos": 1,
-      "total_stars": 8,
-      "total_forks": 2,
-      "recent_issues_count": 8,
-      "activity_frequency": 8,
-      "popularity_score": 12
-    },
-    "dequelabs": {
-      "total_repos": 1,
-      "total_stars": 6592,
-      "total_forks": 839,
-      "recent_issues_count": 1,
-      "activity_frequency": 1,
-      "popularity_score": 8270
-    },
-    "google": {
-      "total_repos": 1,
-      "total_stars": 1323,
-      "total_forks": 318,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 1959
-    },
-    "openedx": {
-      "total_repos": 1,
-      "total_stars": 22,
-      "total_forks": 162,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 346
+      "total_stars": 11310,
+      "total_forks": 5649,
+      "recent_issues_count": 33,
+      "activity_frequency": 33,
+      "popularity_score": 22608
     },
     "XRPLF": {
       "total_repos": 1,
-      "total_stars": 1460,
-      "total_forks": 1100,
+      "total_stars": 1874,
+      "total_forks": 1156,
       "recent_issues_count": 1,
       "activity_frequency": 1,
-      "popularity_score": 3660
+      "popularity_score": 4186
     },
-    "MonishRaman": {
+    "CesiumGS": {
       "total_repos": 1,
-      "total_stars": 27,
-      "total_forks": 67,
+      "total_stars": 15231,
+      "total_forks": 3787,
+      "recent_issues_count": 2,
+      "activity_frequency": 2,
+      "popularity_score": 22805
+    },
+    "stdlib-js": {
+      "total_repos": 1,
+      "total_stars": 5820,
+      "total_forks": 1178,
       "recent_issues_count": 7,
       "activity_frequency": 7,
-      "popularity_score": 161
+      "popularity_score": 8176
     },
-    "arjavjain5203": {
+    "hackforla": {
       "total_repos": 1,
-      "total_stars": 6,
-      "total_forks": 41,
-      "recent_issues_count": 6,
-      "activity_frequency": 6,
-      "popularity_score": 88
+      "total_stars": 64,
+      "total_forks": 47,
+      "recent_issues_count": 11,
+      "activity_frequency": 11,
+      "popularity_score": 158
     },
-    "agamjotsingh18": {
+    "UltiMafia": {
       "total_repos": 1,
-      "total_stars": 11,
-      "total_forks": 68,
-      "recent_issues_count": 5,
-      "activity_frequency": 5,
-      "popularity_score": 147
-    },
-    "Roshansuthar1105": {
-      "total_repos": 1,
-      "total_stars": 34,
-      "total_forks": 76,
-      "recent_issues_count": 4,
-      "activity_frequency": 4,
-      "popularity_score": 186
-    },
-    "eduardconstantin": {
-      "total_repos": 1,
-      "total_stars": 107,
-      "total_forks": 12,
+      "total_stars": 29,
+      "total_forks": 53,
       "recent_issues_count": 1,
       "activity_frequency": 1,
-      "popularity_score": 131
+      "popularity_score": 135
     },
-    "syscoin": {
+    "younisdev": {
       "total_repos": 1,
-      "total_stars": 5,
-      "total_forks": 4,
-      "recent_issues_count": 8,
-      "activity_frequency": 8,
-      "popularity_score": 13
+      "total_stars": 4,
+      "total_forks": 11,
+      "recent_issues_count": 2,
+      "activity_frequency": 2,
+      "popularity_score": 26
     },
-    "YodasWs": {
+    "q5js": {
+      "total_repos": 1,
+      "total_stars": 404,
+      "total_forks": 21,
+      "recent_issues_count": 1,
+      "activity_frequency": 1,
+      "popularity_score": 446
+    },
+    "carnworkstudios": {
+      "total_repos": 1,
+      "total_stars": 1,
+      "total_forks": 1,
+      "recent_issues_count": 3,
+      "activity_frequency": 3,
+      "popularity_score": 3
+    },
+    "OREL-group": {
+      "total_repos": 1,
+      "total_stars": 0,
+      "total_forks": 31,
+      "recent_issues_count": 6,
+      "activity_frequency": 6,
+      "popularity_score": 62
+    },
+    "LOLinDark": {
       "total_repos": 1,
       "total_stars": 0,
       "total_forks": 2,
-      "recent_issues_count": 9,
-      "activity_frequency": 9,
+      "recent_issues_count": 7,
+      "activity_frequency": 7,
       "popularity_score": 4
     },
-    "brave": {
+    "sugarlabs": {
       "total_repos": 1,
-      "total_stars": 20149,
-      "total_forks": 2731,
-      "recent_issues_count": 15,
-      "activity_frequency": 15,
-      "popularity_score": 25611
-    },
-    "plushexe351": {
-      "total_repos": 1,
-      "total_stars": 0,
-      "total_forks": 0,
-      "recent_issues_count": 2,
-      "activity_frequency": 2,
-      "popularity_score": 0
-    },
-    "cboard-org": {
-      "total_repos": 1,
-      "total_stars": 708,
-      "total_forks": 231,
+      "total_stars": 839,
+      "total_forks": 1602,
       "recent_issues_count": 1,
       "activity_frequency": 1,
-      "popularity_score": 1170
+      "popularity_score": 4043
+    },
+    "OSC": {
+      "total_repos": 1,
+      "total_stars": 453,
+      "total_forks": 179,
+      "recent_issues_count": 3,
+      "activity_frequency": 3,
+      "popularity_score": 811
+    },
+    "dbt-labs": {
+      "total_repos": 1,
+      "total_stars": 196,
+      "total_forks": 1154,
+      "recent_issues_count": 3,
+      "activity_frequency": 3,
+      "popularity_score": 2504
+    },
+    "badges": {
+      "total_repos": 1,
+      "total_stars": 26551,
+      "total_forks": 5588,
+      "recent_issues_count": 2,
+      "activity_frequency": 2,
+      "popularity_score": 37727
+    },
+    "wikispeedruns": {
+      "total_repos": 1,
+      "total_stars": 134,
+      "total_forks": 43,
+      "recent_issues_count": 1,
+      "activity_frequency": 1,
+      "popularity_score": 220
+    },
+    "google": {
+      "total_repos": 1,
+      "total_stars": 7649,
+      "total_forks": 1176,
+      "recent_issues_count": 1,
+      "activity_frequency": 1,
+      "popularity_score": 10001
+    },
+    "oss-slu": {
+      "total_repos": 1,
+      "total_stars": 4,
+      "total_forks": 15,
+      "recent_issues_count": 2,
+      "activity_frequency": 2,
+      "popularity_score": 34
+    },
+    "sabbah13": {
+      "total_repos": 1,
+      "total_stars": 4,
+      "total_forks": 1,
+      "recent_issues_count": 5,
+      "activity_frequency": 5,
+      "popularity_score": 6
     }
   },
   "repo_summaries": {
-    "brisbanesocialchess/brisbanesocialchess.github.io": {
-      "stars": 16,
-      "forks": 44,
-      "open_issues": 54,
-      "pushed_at": "2025-09-11T19:29:16Z",
-      "updated_at": "2025-09-11T19:28:51Z",
-      "language": "JavaScript",
-      "recent_issues_count": 13
-    },
-    "layer5io/layer5": {
-      "stars": 948,
-      "forks": 1376,
-      "open_issues": 135,
-      "pushed_at": "2025-09-11T19:22:23Z",
-      "updated_at": "2025-09-11T19:22:28Z",
-      "language": "JavaScript",
-      "recent_issues_count": 8
-    },
-    "MLH-Fellowship/orientation-project-js-25.FAL.A": {
-      "stars": 0,
-      "forks": 0,
-      "open_issues": 12,
-      "pushed_at": "2025-09-11T19:16:08Z",
-      "updated_at": "2025-09-11T19:26:08Z",
-      "language": "JavaScript",
-      "recent_issues_count": 4
-    },
-    "HeyPuter/puter": {
-      "stars": 36129,
-      "forks": 2806,
-      "open_issues": 216,
-      "pushed_at": "2025-09-11T19:12:42Z",
-      "updated_at": "2025-09-11T19:12:50Z",
-      "language": "JavaScript",
-      "recent_issues_count": 32
-    },
-    "vercel/next.js": {
-      "stars": 134344,
-      "forks": 29291,
-      "open_issues": 3330,
-      "pushed_at": "2025-09-11T19:04:43Z",
-      "updated_at": "2025-09-11T19:24:36Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "layer5labs/meshery-extensions-packages": {
-      "stars": 49,
-      "forks": 69,
-      "open_issues": 23,
-      "pushed_at": "2025-09-11T18:54:40Z",
-      "updated_at": "2025-09-11T18:54:44Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "NMRLipids/BilayerGUI_laravel": {
-      "stars": 1,
-      "forks": 3,
-      "open_issues": 12,
-      "pushed_at": "2025-09-11T19:17:16Z",
-      "updated_at": "2025-09-11T18:54:43Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "WordPress/wordpress-playground": {
-      "stars": 1792,
-      "forks": 335,
-      "open_issues": 455,
-      "pushed_at": "2025-09-11T18:44:53Z",
-      "updated_at": "2025-09-11T18:44:34Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "Hylozoic/hylo": {
-      "stars": 13,
-      "forks": 3,
-      "open_issues": 331,
-      "pushed_at": "2025-09-11T18:39:14Z",
-      "updated_at": "2025-09-11T18:38:06Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "open-webui/open-webui": {
-      "stars": 109581,
-      "forks": 14993,
-      "open_issues": 279,
-      "pushed_at": "2025-09-11T18:29:03Z",
-      "updated_at": "2025-09-11T19:23:48Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "eccentriccoder01/Venturalink": {
-      "stars": 7,
-      "forks": 15,
-      "open_issues": 16,
-      "pushed_at": "2025-09-11T18:26:36Z",
-      "updated_at": "2025-09-11T18:26:40Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "PipedreamHQ/pipedream": {
-      "stars": 10556,
-      "forks": 5490,
-      "open_issues": 4237,
-      "pushed_at": "2025-09-11T19:22:05Z",
-      "updated_at": "2025-09-11T18:35:12Z",
-      "language": "JavaScript",
-      "recent_issues_count": 19
-    },
-    "eyaltoledano/claude-task-master": {
-      "stars": 21871,
-      "forks": 2128,
-      "open_issues": 156,
-      "pushed_at": "2025-09-11T18:11:47Z",
-      "updated_at": "2025-09-11T19:26:56Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "open-telemetry/opentelemetry.io": {
-      "stars": 762,
-      "forks": 1516,
-      "open_issues": 450,
-      "pushed_at": "2025-09-11T19:26:56Z",
-      "updated_at": "2025-09-11T17:52:29Z",
-      "language": "JavaScript",
-      "recent_issues_count": 8
-    },
-    "sveltejs/svelte": {
-      "stars": 84066,
-      "forks": 4613,
-      "open_issues": 875,
-      "pushed_at": "2025-09-11T17:38:13Z",
-      "updated_at": "2025-09-11T18:37:16Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "meshery/meshery": {
-      "stars": 7791,
-      "forks": 2567,
-      "open_issues": 785,
-      "pushed_at": "2025-09-11T17:37:42Z",
-      "updated_at": "2025-09-11T19:02:21Z",
-      "language": "JavaScript",
-      "recent_issues_count": 11
-    },
-    "falling-fruit/falling-fruit-web": {
-      "stars": 61,
-      "forks": 37,
-      "open_issues": 80,
-      "pushed_at": "2025-09-11T17:25:37Z",
-      "updated_at": "2025-09-11T17:25:42Z",
-      "language": "JavaScript",
-      "recent_issues_count": 4
-    },
-    "nextcloud/spreed": {
-      "stars": 1991,
-      "forks": 483,
-      "open_issues": 746,
-      "pushed_at": "2025-09-11T17:25:30Z",
-      "updated_at": "2025-09-11T17:22:14Z",
-      "language": "JavaScript",
-      "recent_issues_count": 6
-    },
-    "nodejs/node": {
-      "stars": 113179,
-      "forks": 33040,
-      "open_issues": 2362,
-      "pushed_at": "2025-09-11T17:21:57Z",
-      "updated_at": "2025-09-11T19:26:08Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "Pomax/make-webbly-things": {
-      "stars": 8,
-      "forks": 2,
-      "open_issues": 42,
-      "pushed_at": "2025-09-11T18:18:40Z",
-      "updated_at": "2025-09-11T17:13:42Z",
-      "language": "JavaScript",
-      "recent_issues_count": 8
-    },
-    "dequelabs/axe-core": {
-      "stars": 6592,
-      "forks": 839,
-      "open_issues": 415,
-      "pushed_at": "2025-09-11T17:04:42Z",
-      "updated_at": "2025-09-11T17:04:44Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "google/site-kit-wp": {
-      "stars": 1323,
-      "forks": 318,
-      "open_issues": 574,
-      "pushed_at": "2025-09-11T17:57:24Z",
-      "updated_at": "2025-09-11T17:03:00Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "openedx/frontend-app-account": {
-      "stars": 22,
-      "forks": 162,
-      "open_issues": 36,
-      "pushed_at": "2025-09-11T17:00:54Z",
-      "updated_at": "2025-09-11T17:00:57Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "XRPLF/xrpl-dev-portal": {
-      "stars": 1460,
-      "forks": 1100,
-      "open_issues": 262,
-      "pushed_at": "2025-09-11T16:55:07Z",
-      "updated_at": "2025-09-11T16:55:09Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "layer5io/docs": {
-      "stars": 74,
-      "forks": 133,
-      "open_issues": 72,
-      "pushed_at": "2025-09-11T16:36:02Z",
-      "updated_at": "2025-09-11T16:36:06Z",
-      "language": "JavaScript",
-      "recent_issues_count": 5
-    },
-    "MonishRaman/Placify-Smarter_Placements-Sharper_Talent": {
-      "stars": 27,
-      "forks": 67,
-      "open_issues": 38,
-      "pushed_at": "2025-09-11T16:31:03Z",
-      "updated_at": "2025-09-11T16:31:07Z",
-      "language": "JavaScript",
-      "recent_issues_count": 7
-    },
-    "arjavjain5203/Pustak_Ghar": {
-      "stars": 6,
-      "forks": 41,
-      "open_issues": 35,
-      "pushed_at": "2025-09-11T16:30:22Z",
-      "updated_at": "2025-09-11T16:30:26Z",
-      "language": "JavaScript",
-      "recent_issues_count": 6
-    },
-    "agamjotsingh18/trendhora": {
-      "stars": 11,
-      "forks": 68,
-      "open_issues": 87,
-      "pushed_at": "2025-09-11T16:27:43Z",
-      "updated_at": "2025-09-11T16:27:48Z",
-      "language": "JavaScript",
-      "recent_issues_count": 5
-    },
-    "Roshansuthar1105/Codify": {
-      "stars": 34,
-      "forks": 76,
-      "open_issues": 62,
-      "pushed_at": "2025-09-11T16:22:54Z",
-      "updated_at": "2025-09-11T16:22:58Z",
-      "language": "JavaScript",
-      "recent_issues_count": 4
-    },
-    "eduardconstantin/storybook-genie": {
-      "stars": 107,
-      "forks": 12,
-      "open_issues": 2,
-      "pushed_at": "2025-09-11T16:15:48Z",
-      "updated_at": "2025-09-11T16:15:52Z",
-      "language": "JavaScript",
-      "recent_issues_count": 1
-    },
-    "syscoin/syshub": {
-      "stars": 5,
+    "naimkatiman/continuous-improvement": {
+      "stars": 3,
       "forks": 4,
-      "open_issues": 48,
-      "pushed_at": "2025-09-11T16:14:35Z",
-      "updated_at": "2025-09-11T16:14:20Z",
-      "language": "JavaScript",
-      "recent_issues_count": 8
-    },
-    "YodasWs/Empires-4x": {
-      "stars": 0,
-      "forks": 2,
-      "open_issues": 13,
-      "pushed_at": "2025-09-11T16:10:16Z",
-      "updated_at": "2025-09-11T16:10:20Z",
+      "open_issues": 25,
+      "pushed_at": "2026-05-06T03:11:56Z",
+      "updated_at": "2026-05-06T03:11:25Z",
       "language": "JavaScript",
       "recent_issues_count": 9
     },
-    "brave/brave-browser": {
-      "stars": 20149,
-      "forks": 2731,
-      "open_issues": 9433,
-      "pushed_at": "2025-09-11T16:05:25Z",
-      "updated_at": "2025-09-11T17:50:46Z",
-      "language": "JavaScript",
-      "recent_issues_count": 15
-    },
-    "plushexe351/codepain": {
-      "stars": 0,
-      "forks": 0,
-      "open_issues": 7,
-      "pushed_at": "2025-09-11T16:02:04Z",
-      "updated_at": "2025-09-11T18:03:17Z",
-      "language": "JavaScript",
-      "recent_issues_count": 2
-    },
-    "cboard-org/cboard": {
-      "stars": 708,
-      "forks": 231,
-      "open_issues": 183,
-      "pushed_at": "2025-09-11T16:01:29Z",
-      "updated_at": "2025-09-11T16:01:29Z",
+    "cdxgen/cdxgen": {
+      "stars": 956,
+      "forks": 245,
+      "open_issues": 427,
+      "pushed_at": "2026-05-06T03:02:24Z",
+      "updated_at": "2026-05-06T03:02:27Z",
       "language": "JavaScript",
       "recent_issues_count": 1
     },
     "WordPress/gutenberg": {
-      "stars": 11387,
-      "forks": 4552,
-      "open_issues": 7601,
-      "pushed_at": "2025-09-11T16:28:56Z",
-      "updated_at": "2025-09-11T15:56:13Z",
+      "stars": 11629,
+      "forks": 4791,
+      "open_issues": 7934,
+      "pushed_at": "2026-05-06T02:56:45Z",
+      "updated_at": "2026-05-06T03:02:22Z",
       "language": "JavaScript",
-      "recent_issues_count": 9
+      "recent_issues_count": 8
+    },
+    "vercel/next.js": {
+      "stars": 139286,
+      "forks": 31020,
+      "open_issues": 3885,
+      "pushed_at": "2026-05-06T02:54:53Z",
+      "updated_at": "2026-05-06T02:54:59Z",
+      "language": "JavaScript",
+      "recent_issues_count": 5
+    },
+    "nodejs/node": {
+      "stars": 117043,
+      "forks": 35482,
+      "open_issues": 2650,
+      "pushed_at": "2026-05-06T02:53:39Z",
+      "updated_at": "2026-05-06T02:53:47Z",
+      "language": "JavaScript",
+      "recent_issues_count": 7
+    },
+    "HarperFast/harper": {
+      "stars": 75,
+      "forks": 5,
+      "open_issues": 116,
+      "pushed_at": "2026-05-06T03:09:46Z",
+      "updated_at": "2026-05-06T02:14:07Z",
+      "language": "JavaScript",
+      "recent_issues_count": 3
+    },
+    "nextcloud/tables": {
+      "stars": 205,
+      "forks": 41,
+      "open_issues": 345,
+      "pushed_at": "2026-05-06T01:56:14Z",
+      "updated_at": "2026-05-06T01:56:18Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "medic/cht-core": {
+      "stars": 537,
+      "forks": 382,
+      "open_issues": 701,
+      "pushed_at": "2026-05-06T01:37:54Z",
+      "updated_at": "2026-05-06T01:54:07Z",
+      "language": "JavaScript",
+      "recent_issues_count": 6
+    },
+    "meshery/meshery.io": {
+      "stars": 755,
+      "forks": 782,
+      "open_issues": 50,
+      "pushed_at": "2026-05-06T01:21:27Z",
+      "updated_at": "2026-05-06T01:19:22Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "LovelyStoOk/PLATAFORMA-DE-GESTI-N-DE-PROYECTOS-ESTILO-KANBAN": {
+      "stars": 0,
+      "forks": 0,
+      "open_issues": 5,
+      "pushed_at": "2026-05-06T01:03:37Z",
+      "updated_at": "2026-05-06T01:03:40Z",
+      "language": "JavaScript",
+      "recent_issues_count": 2
+    },
+    "HeyPuter/puter": {
+      "stars": 40925,
+      "forks": 3719,
+      "open_issues": 16,
+      "pushed_at": "2026-05-06T00:43:30Z",
+      "updated_at": "2026-05-06T03:02:24Z",
+      "language": "JavaScript",
+      "recent_issues_count": 2
+    },
+    "layer5io/layer5": {
+      "stars": 1041,
+      "forks": 1528,
+      "open_issues": 92,
+      "pushed_at": "2026-05-06T00:53:44Z",
+      "updated_at": "2026-05-06T00:36:28Z",
+      "language": "JavaScript",
+      "recent_issues_count": 16
+    },
+    "nextcloud/spreed": {
+      "stars": 2108,
+      "forks": 528,
+      "open_issues": 833,
+      "pushed_at": "2026-05-06T00:24:26Z",
+      "updated_at": "2026-05-06T00:24:26Z",
+      "language": "JavaScript",
+      "recent_issues_count": 11
+    },
+    "louislam/uptime-kuma": {
+      "stars": 86265,
+      "forks": 7784,
+      "open_issues": 732,
+      "pushed_at": "2026-05-06T00:18:53Z",
+      "updated_at": "2026-05-06T03:08:18Z",
+      "language": "JavaScript",
+      "recent_issues_count": 5
+    },
+    "nodejs/undici": {
+      "stars": 7548,
+      "forks": 758,
+      "open_issues": 322,
+      "pushed_at": "2026-05-06T00:17:16Z",
+      "updated_at": "2026-05-06T01:43:40Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "PipedreamHQ/pipedream": {
+      "stars": 11310,
+      "forks": 5649,
+      "open_issues": 4465,
+      "pushed_at": "2026-05-06T00:04:57Z",
+      "updated_at": "2026-05-06T01:58:44Z",
+      "language": "JavaScript",
+      "recent_issues_count": 33
+    },
+    "XRPLF/xrpl-dev-portal": {
+      "stars": 1874,
+      "forks": 1156,
+      "open_issues": 238,
+      "pushed_at": "2026-05-05T23:57:17Z",
+      "updated_at": "2026-05-06T00:29:06Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "CesiumGS/cesium": {
+      "stars": 15231,
+      "forks": 3787,
+      "open_issues": 1590,
+      "pushed_at": "2026-05-05T23:23:13Z",
+      "updated_at": "2026-05-06T02:57:00Z",
+      "language": "JavaScript",
+      "recent_issues_count": 2
+    },
+    "stdlib-js/stdlib": {
+      "stars": 5820,
+      "forks": 1178,
+      "open_issues": 1245,
+      "pushed_at": "2026-05-06T03:03:33Z",
+      "updated_at": "2026-05-05T23:13:29Z",
+      "language": "JavaScript",
+      "recent_issues_count": 7
+    },
+    "hackforla/tdm-calculator": {
+      "stars": 64,
+      "forks": 47,
+      "open_issues": 399,
+      "pushed_at": "2026-05-05T23:07:15Z",
+      "updated_at": "2026-05-05T23:07:18Z",
+      "language": "JavaScript",
+      "recent_issues_count": 11
+    },
+    "UltiMafia/Ultimafia": {
+      "stars": 29,
+      "forks": 53,
+      "open_issues": 63,
+      "pushed_at": "2026-05-05T23:06:15Z",
+      "updated_at": "2026-05-05T23:06:21Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "younisdev/dyvix-ui": {
+      "stars": 4,
+      "forks": 11,
+      "open_issues": 11,
+      "pushed_at": "2026-05-05T22:43:21Z",
+      "updated_at": "2026-05-05T22:43:29Z",
+      "language": "JavaScript",
+      "recent_issues_count": 2
+    },
+    "q5js/q5.js": {
+      "stars": 404,
+      "forks": 21,
+      "open_issues": 16,
+      "pushed_at": "2026-05-05T22:35:19Z",
+      "updated_at": "2026-05-05T22:35:23Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "carnworkstudios/TAFNE": {
+      "stars": 1,
+      "forks": 1,
+      "open_issues": 5,
+      "pushed_at": "2026-05-05T22:35:06Z",
+      "updated_at": "2026-05-05T22:35:10Z",
+      "language": "JavaScript",
+      "recent_issues_count": 3
+    },
+    "OREL-group/Project-Management": {
+      "stars": 0,
+      "forks": 31,
+      "open_issues": 157,
+      "pushed_at": "2026-05-05T22:33:05Z",
+      "updated_at": "2026-05-05T22:33:09Z",
+      "language": "JavaScript",
+      "recent_issues_count": 6
+    },
+    "LOLinDark/StreamerOps": {
+      "stars": 0,
+      "forks": 2,
+      "open_issues": 9,
+      "pushed_at": "2026-05-05T21:42:59Z",
+      "updated_at": "2026-05-05T21:43:03Z",
+      "language": "JavaScript",
+      "recent_issues_count": 7
+    },
+    "sugarlabs/musicblocks": {
+      "stars": 839,
+      "forks": 1602,
+      "open_issues": 473,
+      "pushed_at": "2026-05-05T21:35:47Z",
+      "updated_at": "2026-05-05T21:35:22Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "OSC/ondemand": {
+      "stars": 453,
+      "forks": 179,
+      "open_issues": 430,
+      "pushed_at": "2026-05-05T20:36:03Z",
+      "updated_at": "2026-05-05T20:36:07Z",
+      "language": "JavaScript",
+      "recent_issues_count": 3
+    },
+    "dbt-labs/docs.getdbt.com": {
+      "stars": 196,
+      "forks": 1154,
+      "open_issues": 193,
+      "pushed_at": "2026-05-05T22:18:00Z",
+      "updated_at": "2026-05-05T20:23:49Z",
+      "language": "JavaScript",
+      "recent_issues_count": 3
+    },
+    "badges/shields": {
+      "stars": 26551,
+      "forks": 5588,
+      "open_issues": 341,
+      "pushed_at": "2026-05-05T20:20:49Z",
+      "updated_at": "2026-05-06T02:44:28Z",
+      "language": "JavaScript",
+      "recent_issues_count": 2
+    },
+    "wikispeedruns/wikipedia-speedruns": {
+      "stars": 134,
+      "forks": 43,
+      "open_issues": 126,
+      "pushed_at": "2026-05-05T20:05:22Z",
+      "updated_at": "2026-05-05T20:05:28Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "google/closure-compiler": {
+      "stars": 7649,
+      "forks": 1176,
+      "open_issues": 911,
+      "pushed_at": "2026-05-05T19:59:47Z",
+      "updated_at": "2026-05-06T00:11:10Z",
+      "language": "JavaScript",
+      "recent_issues_count": 1
+    },
+    "oss-slu/DigitalBoneBox": {
+      "stars": 4,
+      "forks": 15,
+      "open_issues": 67,
+      "pushed_at": "2026-05-05T19:42:43Z",
+      "updated_at": "2026-05-05T19:42:13Z",
+      "language": "JavaScript",
+      "recent_issues_count": 2
+    },
+    "sabbah13/cowork-tasks": {
+      "stars": 4,
+      "forks": 1,
+      "open_issues": 7,
+      "pushed_at": "2026-05-05T21:00:27Z",
+      "updated_at": "2026-05-05T19:49:51Z",
+      "language": "JavaScript",
+      "recent_issues_count": 5
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the `markdown-to-html` dependency with a direct HTML writer in `index.js`
- Embeds `data-updated` (issue activity date) and `data-index` (original order) on each issue `<li>`
- Adds two one-click toggle buttons to `index.html`:
  - **Sort by most recent** — reorders repo sections and issues within them by `issue.updated_at`
  - **Hide inactive issues** — hides issues with no activity in 7+ days; hides the repo section entirely if all its issues are filtered out

## Test plan
- [ ] Run `npm start` to regenerate `index.html`
- [ ] Open `index.html` in a browser
- [ ] Click "Sort by most recent" — verify repo sections reorder and issues within each section reorder
- [ ] Click again — verify original order is restored
- [ ] Click "Hide inactive issues" — verify stale issues disappear, and repos with no remaining issues are hidden
- [ ] Click again — verify everything reappears

Closes #56