### PR TITLE
fix: exit non-zero on script failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ const getGoodFirstIssues = async () => {
     fs.writeFileSync('README.md', markdown);
   } catch (error) {
     console.error(`An error occurred: ${error.message}`);
-    process.exit();
+    process.exit(1);
   }
 };
 
@@ -207,7 +207,7 @@ const convertToHtml = async () => {
     });
   } catch (e) {
     console.error('>>>' + e);
-    process.exit();
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
## Summary
- Fixes #64
- Return exit code 1 when issue generation fails
- Return exit code 1 when HTML conversion fails

## Verification
- `node --check index.js`
- Isolated Node VM regression harness with filesystem and network dependencies stubbed: forced both failure paths and confirmed each calls `process.exit(1)`
- `git diff --check`